### PR TITLE
Fix for ucs_tcga maf

### DIFF
--- a/public/ucs_tcga.tar.gz
+++ b/public/ucs_tcga.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a13c64e2c50622c5005e79e443ec28f39f55b438b9880cf4ccba057f7f60ed8f
-size 22939639
+oid sha256:e4514ef5451151278f95ce123ebf897e1c49850cc5c89d663f6d4d60024d6afb
+size 22487480


### PR DESCRIPTION
The ucs_tcga maf was missing some values for ref/tumor seq allele.

@jjgao @n1zea144 