### PR TITLE
Mass spec fixes

### DIFF
--- a/public/brca_tcga.tar.gz
+++ b/public/brca_tcga.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:900274e0ef3ce11d809e31ec0ba877ac657b6e35cee3977f9ba823a31b28881d
-size 387199252
+oid sha256:bbddba50ee774cd90a666408b3706df2ddcbb19795dd503a4bd4f317e66671cd
+size 387208658

--- a/public/coadread_tcga.tar.gz
+++ b/public/coadread_tcga.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f2bf0ef1a887c7c520e95af19dadb270c1eb0392b4dc799c3bccf52154356e2
-size 159295499
+oid sha256:644003bdc6caeeb0aadcb21275a3d39ea050b219802265b618d12714555754ba
+size 159310909

--- a/public/ov_tcga.tar.gz
+++ b/public/ov_tcga.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f22d109c3cb4047bf7978efe17f6f2aa419cb400aedb9123fea56fc0cb82ea53
-size 197438890
+oid sha256:137e8587a96321b10cbc19fadf44f68be7b5a797dee7e10cf94fcd371e48ed5a
+size 197446861


### PR DESCRIPTION
Fixes issues in #32 for brca, coadread, and ov TCGA studies.