### PR TITLE
Update seed database to 2.6.0

### DIFF
--- a/seedDB/README.md
+++ b/seedDB/README.md
@@ -5,15 +5,34 @@ These files are MySQL database dump files for seeding a new instance of the cBio
 The database schema and cBioPortal release follows different numbering cycles since cBioPortal 1.5.0 and database schema 2.1.0. This means that the version numbers won't be identical. cBioPortal 1.9.0 with database schema 2.4.0 removed PDB annotations from the database.
 
 ## Latest seed database
+#### Seed database schema 2.6.0
+
+This schema is required for cBioPortal release versions:
+- **1.12.x**
+- **1.13.x**
+- **1.14.0**
+
+When using a release version **> 1.14.0**, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
+
+**Schema 2.6.0**: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.13.1/db-scripts/src/main/resources/cgds.sql)<br>
+**Seed database**: [seed-cbioportal_hg19_v2.6.0.sql.gz](https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.6.0.sql.gz)<br>
+md5sum 01a1db3ae38d160d27af23c2f7db86f7
+
+Contents of seed database:
+- Entrez Gene IDs, HGNC symbols and gene aliases updated in April 2018 from [NCBI](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz)
+- Gene lengths retrieved from [Gencode Release 27 (mapped to GRCh37)](https://www.gencodegenes.org/releases/27lift37.html)
+- Pfam graphics fetched in August 2017
+
+## Previous seed databases
 #### Seed database schema 2.4.0
 
 This schema is required for cBioPortal release versions:
-- **1.9.0**
+- 1.9.0
 
-When using a release version **> 1.9.0**, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
+When using a release version > 1.9.0, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
 
-**Schema 2.4.0**: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.9.0/db-scripts/src/main/resources/cgds.sql)<br>
-**Seed database :** [seed-cbioportal_hg19_v2.4.0.sql.gz](https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.4.0.sql.gz)<br>
+Schema 2.4.0: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.9.0/db-scripts/src/main/resources/cgds.sql)<br>
+Seed database : [seed-cbioportal_hg19_v2.4.0.sql.gz](https://github.com/cBioPortal/datahub/raw/b9662010756188a18051c983b8c445dd033703a9/seedDB/seed-cbioportal_hg19_v2.4.0.sql.gz)<br>
 md5sum 1014ed1f9d72103f2b46e5615aacbc2f
 
 Contents of seed database:
@@ -21,7 +40,6 @@ Contents of seed database:
 - Gene lengths retrieved from Gencode Release 26 (mapped to GRCh37)
 - Pfam graphics fetched in August 2017
 
-## Previous seed databases
 #### Seed database schema 2.3.1
 
 This schema is required for cBioPortal release versions:

--- a/seedDB/Update-Seed-Database.md
+++ b/seedDB/Update-Seed-Database.md
@@ -14,11 +14,17 @@ mysqldump -u cbio -pP@ssword1 -P 8306 --host 127.0.0.1 --ignore-table cbioportal
 ```
 :warning: The database schema is not included in these dump files.
 
-4. Zip the generated mysql dump files:
+4. In case gene sets are included in the seed, manually add a line at the end the sql file to update the gene set version.
+```bash
+-- Manually add gene set version
+UPDATE info SET GENESET_VERSION="msigdb_6.1";
+```
+
+5. Zip the generated mysql dump files:
 ```shell
 gzip seed-cbioportal_hg19_v2.1.0.sql
 ```
 
-5. New files are ready to be uploaded to datahub.
+6. New files are ready to be uploaded to datahub.
 
 :warning: The database schema itself is found at: `$PORTAL_HOME/db-scripts/src/main/resources/db/cgds.sql`

--- a/seedDB/seed-cbioportal_hg19_v2.4.0.sql.gz
+++ b/seedDB/seed-cbioportal_hg19_v2.4.0.sql.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cff6f027f45712d595d16589010f213e7f2ca45bd69ecd59484c2769838342e3
-size 52246532

--- a/seedDB/seed-cbioportal_hg19_v2.6.0.sql.gz
+++ b/seedDB/seed-cbioportal_hg19_v2.6.0.sql.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0fee27a47b202ed42aad57be1e8c52caaaa8f30c7ec499c8d16194d3a2a6e93
+size 60126083


### PR DESCRIPTION
- Update database schema to 2.6.0
- Load MSigDB 6.1 gene sets in seed
- Load gene set hierarchy data in seed
- Update documentation
- Update genes (April 2018 from NCBI)
- Update gene lengths (Gencode Release 27)

### 2.4.0 statistics
Genes: 59976
Gene aliases: 66134
Pfam graphics: 21361
Info: DB_SCHEMA_VERSION: 2.4.0; GENESET_VERSION: null

### 2.6.0 statistics
Genes: 60070
Gene aliases: 66840
Gene sets: 17786
Pfam graphics: 21361
Info: DB_SCHEMA_VERSION: 2.6.0; GENESET_VERSION: msigdb_6.1