### PR TITLE
Use seed database info for validation of studies

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -41,7 +41,7 @@ if [[ $num_studies > 0 ]]; then
   echo $list_csv
 
   test_reports_location="$HOME/repo/test-reports"
-  validation_command="$HOME/repo/cbioportal/core/src/main/scripts/importer/./validateStudies.py -d $HOME/repo/ -l $list_csv -u http://www.cbioportal.org -html $test_reports_location"
+  validation_command="$HOME/repo/cbioportal/core/src/main/scripts/importer/./validateStudies.py -d $HOME/repo/ -l $list_csv -p $HOME/repo/.circleci/portalinfo -html $test_reports_location"
   echo $'\nExecuting: '; echo $validation_command
   if sh -c "$validation_command" ; then
     echo "Tests passed successfully"


### PR DESCRIPTION
# What?
Use seed database info for validation of studies.

The seed contains the genes, aliases and cancer types used for new cBio instances, so we have to make sure the studies on datahub validate using those definitions. We will have to add new cancer types from OncoTree to the outdated `type_of_cancer` table in the seed database.