### PR TITLE
Ignore archived_files for validation

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -17,7 +17,7 @@ do
       dir_name=`dirname $file_changing`
       # match case_list*, caselist* as a case list dir (actually only case_lists is valid, 
       # but this is up to validation script to flag):
-      if [[ $dir_name != *"/case_list"* ]] && [[ $dir_name != *"/caselist"* ]]; then
+      if [[ $dir_name != *"/case_list"* ]] && [[ $dir_name != *"/caselist"* ]] && [[ $dir_name != *"/archived_files"* ]]; then
         echo "study dir > [$dir_name]"
       else
         # get parent dir:


### PR DESCRIPTION
This PR tells circleCI to ignore the directory `archived_files`. This is the directory that contains files that are not used by cBioPortal but should be present with the staging files for a study.

This will fix 
https://github.com/cBioPortal/datahub/pull/319

Tested in 
https://github.com/cBioPortal/datahub/pull/323