### PR TITLE
Adding changes to msk_impact_2017 study as suggested in issue #316

### DIFF
--- a/public/msk_impact_2017/data_clinical_sample.txt
+++ b/public/msk_impact_2017/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:310e8c5e04ed6392c6f68dac2c4dd0dae1ab964df966b7577cf9b25e0cf95f54
-size 1206144
+oid sha256:f8e537274640b4be0ddb49b5efad4f8de20c21625c128ba5ea7797454fb05101
+size 1705193


### PR DESCRIPTION
# What?
Fix #316  .

Cancer studies updated in this pull request:
- msk_impact_2017 (data_clinical_sample.txt)
- .

# checks
For all pull requests:
- [x] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

