### PR TITLE
Replace \r line breaks with \n in clin patient brca_tcga_pub

### DIFF
--- a/public/brca_tcga_pub/data_clinical_patient.txt
+++ b/public/brca_tcga_pub/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ef085befa96f4e06eaefe2157c1177d94febb42b62f6d53d1fe381726b38f65
-size 34697
+oid sha256:c6523659185177750ba963f28b43c844ad391eb415accfdd00e796ca3db607f4
+size 34698


### PR DESCRIPTION
# What?
- Replace \r line breaks with \n in clin patient brca_tcga_pub

This was causing issues with command line text readers such as Vim.