### PR TITLE
Removed RPPA data since the samples are not for liver cases

### DIFF
--- a/public/lihc_tcga/data_rppa.txt
+++ b/public/lihc_tcga/data_rppa.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f87b5f6e62f4ab812e7ce2f724ea49d46fcbd226a0bb5c5f475d3dd7d3a16e37
-size 171239

--- a/public/lihc_tcga/data_rppa_Zscores.txt
+++ b/public/lihc_tcga/data_rppa_Zscores.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46880b74499aeb933612f57c3a99603e97e83a9559e1c086e21298fe17f809cc
-size 94652

--- a/public/lihc_tcga/meta_rppa.txt
+++ b/public/lihc_tcga/meta_rppa.txt
@@ -1,8 +1,0 @@
-cancer_study_identifier: lihc_tcga
-genetic_alteration_type: PROTEIN_LEVEL
-datatype: LOG2-VALUE
-data_filename: data_rppa.txt
-stable_id: rppa
-show_profile_in_analysis_tab: false
-profile_description: Protein expression measured by reverse-phase protein array
-profile_name: Protein expression (RPPA)

--- a/public/lihc_tcga/meta_rppa_Zscores.txt
+++ b/public/lihc_tcga/meta_rppa_Zscores.txt
@@ -1,8 +1,0 @@
-cancer_study_identifier: lihc_tcga
-genetic_alteration_type: PROTEIN_LEVEL
-datatype: Z-SCORE
-data_filename: data_rppa_Zscores.txt
-stable_id: rppa_Zscores
-show_profile_in_analysis_tab: true
-profile_description: Protein expression, measured by reverse-phase protein array, Z-scores
-profile_name: Protein expression Z-scores (RPPA)


### PR DESCRIPTION
# What?
Fix # .

Cancer studies updated in this pull request:
- a
- .

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

