### PR TITLE
Removing manual Zscores for regeneration

### DIFF
--- a/public/brca_tcga_pub2015/data_expression_median_microRNA_removed.txt
+++ b/public/brca_tcga_pub2015/data_expression_median_microRNA_removed.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ea73a959004c5f7af0924e2a4348a60628914ea126f325527b796b5632a36f0
-size 10277

--- a/public/brca_tcga_pub2015/data_expression_median_normals.txt
+++ b/public/brca_tcga_pub2015/data_expression_median_normals.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfa1a822511ccd726e5d6bd661d2395d649c346f8469e40f7a0416e0bcbcb37f
-size 10795847


### PR DESCRIPTION
# What?
Fix # .

Cancer studies updated in this pull request:
- a
- .

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

