### PR TITLE
Removed Zscores for regeneration

### DIFF
--- a/public/brca_tcga_pub2015/data_RNA_Seq_v2_expression_median_normals.txt
+++ b/public/brca_tcga_pub2015/data_RNA_Seq_v2_expression_median_normals.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6619e6d3013bda401af649167a113c71a2132183a4913cdfa15a6543e3e671d7
-size 19857610

--- a/public/brca_tcga_pub2015/data_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/data_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5bfd35e9fab67622206ff3956de15471cfcbebe3bcef63faa18ca8bf5997ee52
-size 73133170

--- a/public/brca_tcga_pub2015/data_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/data_mRNA_median_Zscores.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61e9a26f51cde3390508599ed6df6b64b607a6089d55d45f158391b9fb8303fe
-size 53104761

--- a/public/brca_tcga_pub2015/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -1,8 +1,0 @@
-cancer_study_identifier: brca_tcga_pub2015
-genetic_alteration_type: MRNA_EXPRESSION
-datatype: Z-SCORE
-stable_id: rna_seq_v2_mrna_median_Zscores
-show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
-data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt

--- a/public/brca_tcga_pub2015/meta_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/meta_mRNA_median_Zscores.txt
@@ -1,8 +1,0 @@
-cancer_study_identifier: brca_tcga_pub2015
-genetic_alteration_type: MRNA_EXPRESSION
-datatype: Z-SCORE
-stable_id: mrna_median_Zscores
-show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
-data_filename: data_mRNA_median_Zscores.txt


### PR DESCRIPTION
# What?
Fix # .

Cancer studies updated in this pull request:
- a
- .

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

