### PR TITLE
Fix prad_broad_2013 seg data

### DIFF
--- a/public/prad_broad_2013/prad_broad_2013_data_cna_hg19.seg
+++ b/public/prad_broad_2013/prad_broad_2013_data_cna_hg19.seg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:478df9d3f44cc597024f400699c910d5a6927d7c5f95325af7bafd990ff79e99
+size 808477

--- a/public/prad_broad_2013/prad_broad_2013_meta_cna_hg19_seg.txt
+++ b/public/prad_broad_2013/prad_broad_2013_meta_cna_hg19_seg.txt
@@ -1,0 +1,6 @@
+cancer_study_identifier: prad_broad_2013
+reference_genome_id: hg19
+description: Somatic CNA data (copy number ratio from tumor samples minus ratio from matched normals) from TCGA.
+data_filename: prad_broad_2013_data_cna_hg19.seg
+genetic_alteration_type: COPY_NUMBER_ALTERATION
+datatype: SEG


### PR DESCRIPTION
# What?
fixed issue https://github.com/cBioPortal/datahub/issues/314
added back seg (was marked as hg18 actually is hg19 after checking the original publication)
