### PR TITLE
Update seed database to 2.7.2 and add CI tests 

### DIFF
--- a/.circleci/check_changed_seed.sh
+++ b/.circleci/check_changed_seed.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# This script detects if seed database file is changed and triggers the validation accordingly
+
+SEED_PREFIX="seedDB/seed-cbioportal_"
+
+git remote add upstream git@github.com:cbioportal/datahub.git
+git fetch upstream master
+files_changing=`git diff --name-only --diff-filter=ACMRU upstream/master`
+
+# Remove upstream remote here because python code will create it again.
+git remote rm upstream
+
+for file_changing in $files_changing
+do
+  echo "file > [$file_changing]"
+  if [[ $file_changing == *$SEED_PREFIX* ]]; then
+    docker network create cbio-net
+    docker run -t -d --net=cbio-net --name python_circleci -v /var/run/docker.sock:/var/run/docker.sock -v /home/circleci/repo/:/home/circleci/repo/:rw -w /home/circleci/repo/.circleci circleci/python:3.6
+    docker exec python_circleci bash install_dependencies.sh
+    docker exec -t python_circleci sudo python validate_changed_seed.py
+  fi
+done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,18 +62,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Start docker container with python3
+          name: Check for changed seed database and run validation if necessary
           command: |
-            docker network create cbio-net
-            docker run -t -d --net=cbio-net --name python_circleci -v /var/run/docker.sock:/var/run/docker.sock -v /home/circleci/repo/:/home/circleci/repo/:rw -w /home/circleci/repo/.circleci circleci/python:3.6
-      - run:
-          name: Install dependencies
-          command: |
-            docker exec python_circleci bash install_dependencies.sh
-      - run:
-          name: Validate changed seed
-          command: |
-            docker exec -t python_circleci sudo python validate_changed_seed.py
+            cd ~/repo/.circleci
+            ./check_changed_seed.sh
 
 # Workflow containing the different jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: validate changed studies
+          name: Validate changed studies
           command: |
             cd ~/repo/.circleci
             ./install_dependencies.sh
             ./validate_changed_studies.sh
       - store_artifacts:
-          path: test-reports
-          destination: test-reports
+          path: ~/test-reports
+          destination: ~/test-reports
 
   # Job to validate all studies
   validate_all_studies:
@@ -30,7 +30,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: validate all studies
+          name: Validate all studies
           command: |
             cd ~/repo/.circleci
             ./install_dependencies.sh
@@ -53,6 +53,28 @@ jobs:
             sudo pip install "requests==2.10.0"
             ./validate_datahub_with_cbioportal.py
 
+  # Job to validate the seed database
+  validate_changed_seed:
+    # This is required to mount volumes when starting a new docker container, see:
+    # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-mount-volumes-to-docker-containers-
+    machine: true
+    working_directory: ~/repo/
+    steps:
+      - checkout
+      - run:
+          name: Start docker container with python3
+          command: |
+            docker network create cbio-net
+            docker run -t -d --net=cbio-net --name python_circleci -v /var/run/docker.sock:/var/run/docker.sock -v /home/circleci/repo/:/home/circleci/repo/:rw -w /home/circleci/repo/.circleci circleci/python:3.6
+      - run:
+          name: Install dependencies
+          command: |
+            docker exec python_circleci bash install_dependencies.sh
+      - run:
+          name: Validate changed seed
+          command: |
+            docker exec python_circleci sudo python validate_changed_seed.py
+
 # Workflow containing the different jobs
 workflows:
   version: 2
@@ -62,6 +84,10 @@ workflows:
   workflow_on_commit:
     jobs:
       - build:
+          filters:
+            branches:
+              ignore: master
+      - validate_changed_seed:
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - run:
           name: Validate changed seed
           command: |
-            docker exec python_circleci sudo python validate_changed_seed.py
+            docker exec -t python_circleci sudo python validate_changed_seed.py
 
 # Workflow containing the different jobs
 workflows:

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -3,10 +3,10 @@
 
 # Install python dependencies
 cd ~/repo/.circleci
-sudo pip install -r requirements_py
+sudo pip install -r requirements.txt
 
 # Install and configure Git LFS
-cd ~/repo
+cd ~/
 wget https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-linux-amd64-2.3.4.tar.gz
 tar -xvf git-lfs-linux-amd64-2.3.4.tar.gz
 cd git-lfs-2.3.4
@@ -16,9 +16,10 @@ sudo chown -R circleci .git
 git lfs install --skip-smudge
 
 # Clone datahub master branch
+cd ~/
 git clone --depth 1 -b master https://github.com/cbioportal/cbioportal.git
 
 # Make test reports location
-cd ~/repo/.circleci
-mkdir ~/repo/test-reports
-mkdir ~/repo/test-reports/ERRORS
+cd ~/
+mkdir ~/test-reports
+mkdir ~/test-reports/ERRORS

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,0 +1,6 @@
+requests==2.19.1
+Jinja2==2.8
+mysqlclient==1.3.13
+docker==3.5.0
+gitpython==2.1.11
+urllib3==1.23

--- a/.circleci/requirements_py
+++ b/.circleci/requirements_py
@@ -1,3 +1,0 @@
-requests==2.10.0
-Jinja2==2.8
-mysqlclient==1.3.13

--- a/.circleci/validate_changed_seed.py
+++ b/.circleci/validate_changed_seed.py
@@ -55,7 +55,7 @@ def check_changed_seed():
             seed_files.add(changed_file)
 
     if len(seed_files) == 0:
-        print('Seed database files are not changed')
+        print('Seed database files are not changed. It is not necessary to the the seed database.')
         sys.exit(0)
     elif len(seed_files) > 1:
         eprint('Found multiple seed databases. Unable to test whether seed is updated correctly.')
@@ -197,7 +197,7 @@ def check_info_table(cursor):
     info_values = cursor.fetchall()[0]
     if not (len(info_values)) == 2:
         eprint('The "info" table contains other than 2 values: %s' % info_values)
-    if info_values[1] is None or info_values[1] == '':
+    elif info_values[1] is None or info_values[1] == '':
         eprint('Missing gene set version in seed database. This is a manual addition to the automated database dump.\n'
                'See step 6 at https://github.com/cBioPortal/datahub/blob/master/seedDB/Update-Seed-Database.md')
     else:
@@ -231,6 +231,9 @@ def main():
 
     # Check the info table for empty values
     check_info_table(cursor)
+
+    print('\n')
+    print('Tests completed. The updated seed database seems valid.')
 
 
 if __name__ == '__main__':

--- a/.circleci/validate_changed_seed.py
+++ b/.circleci/validate_changed_seed.py
@@ -1,0 +1,237 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2018 The Hyve B.V.
+# This code is licensed under the GNU Affero General Public License (AGPL),
+# version 3, or (at your option) any later version.
+#
+# This file is part of cBioPortal.
+#
+# cBioPortal is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Validate changed seed - Validate if the new seed database does not contain any of the checked errors.
+"""
+
+import MySQLdb
+import sys
+import os
+import git
+import docker
+import urllib.request
+import time
+import _mysql_exceptions
+from time import gmtime, strftime
+
+
+def eprint(*args, **kwargs):
+    """Print error message and exit"""
+    print(*args, file=sys.stderr, **kwargs)
+    sys.exit(1)
+
+
+def check_changed_seed():
+    """Check whether the seed database files are changed"""
+
+    # Check whether the seed has changed
+    repo = git.Repo(os.path.dirname(os.getcwd()))
+    remote = repo.create_remote('upstream', url='https://github.com/cBioPortal/datahub/')
+    remote.fetch()
+    changed_files = repo.git.diff('upstream/master', name_only=True, diff_filter='ACMRU').split('\n')
+
+    seed_files = set()
+    for changed_file in changed_files:
+        if 'seedDB/seed-cbioportal_' in changed_file:
+            seed_files.add(changed_file)
+
+    if len(seed_files) == 0:
+        print('Seed database files are not changed')
+        sys.exit(0)
+    elif len(seed_files) > 1:
+        eprint('Found multiple seed databases. Unable to test whether seed is updated correctly.')
+
+    seed_file = list(seed_files)[0]
+    return seed_file
+
+
+def start_mysql_database(seed_location):
+    """Start a mysql database with the seed files"""
+
+    # Prepare to start a mysql database with cbioportal seed
+    client = docker.from_env()
+    database_location = os.path.join(os.getcwd(), 'db_files')
+    schema_url = 'https://raw.githubusercontent.com/cBioPortal/cbioportal/master/db-scripts/src/main/resources/cgds.sql'
+    schema_location = os.path.join(os.getcwd(), 'cgds.sql')
+    urllib.request.urlretrieve(schema_url, schema_location)
+    docker_sock_location = '/var/run/docker.sock'
+
+    # Start database
+    client.containers.run("mysql:5.7",
+                          name='cbioDB',
+                          network='cbio-net',
+                          detach=True,
+                          environment={'MYSQL_ROOT_PASSWORD': 'P@ssword1',
+                                       'MYSQL_USER': 'cbio',
+                                       'MYSQL_PASSWORD': 'P@ssword1',
+                                       'MYSQL_DATABASE': 'cbioportal',
+                                       },
+                          ports={'3306/tcp': 3306},
+                          volumes={database_location: {'bind': '/var/lib/mysql/', 'mode': 'rw'},
+                                   schema_location: {'bind': '/docker-entrypoint-initdb.d/cgds.sql', 'mode': 'ro'},
+                                   seed_location: {'bind': '/docker-entrypoint-initdb.d/seed_part1.sql.gz',
+                                                   'mode': 'ro'},
+                                   docker_sock_location: {'bind': docker_sock_location, 'mode': 'rw'}
+                                   },
+                          )
+
+    # Check then the docker container is up
+    connected = False
+    database = ''
+    tries = 0
+    max_tries = 10
+    while not connected:
+        try:
+            tries += 1
+            database = MySQLdb.connect(host='cbioDB', port=3306, user='cbio', passwd='P@ssword1', db='cbioportal',
+                                       connect_timeout=500)
+            connected = True
+        except _mysql_exceptions.OperationalError:
+            print(strftime("%H:%M:%S", gmtime()) + ' Database container is not ready (%s/%s)' % (tries, max_tries))
+            if tries == max_tries:
+                eprint('Cannot connect to MySQL database container')
+            time.sleep(60)
+            pass
+
+    print(strftime("%H:%M:%S", gmtime()) + ' Database container is ready!\n')
+    return database
+
+
+def check_gene_table(cursor):
+    """Check whether the seed database contains values."""
+
+    cursor.execute('SELECT count(*) FROM cbioportal.gene')
+    number_genes = cursor.fetchone()[0]
+    if number_genes == 0:
+        eprint('No genes in seed database')
+    elif number_genes < 55000:
+        # The seed in September 2018 contains 60070 genes.
+        eprint('Unexpected low number of genes in seed database: %s' % number_genes)
+    else:
+        print('Genes in seed database: %s' % number_genes)
+
+
+def check_gene_alias_table(cursor):
+    """Check whether the gene alias table contains values."""
+
+    cursor.execute('SELECT count(*) FROM cbioportal.gene_alias')
+    number_aliases = cursor.fetchone()[0]
+    if number_aliases == 0:
+        eprint('No genes in seed database')
+    elif number_aliases < 65000:
+        # The seed in September 2018 contains 66840 gene aliases.
+        eprint('Unexpected low number of gene aliases in seed database: %s' % number_aliases)
+    else:
+        print('Gene aliases in seed database: %s' % number_aliases)
+
+
+def check_cancer_type_table(cursor):
+    """ Check whether the cancer types table contains values."""
+
+    cursor.execute('SELECT count(*) FROM cbioportal.type_of_cancer')
+    number_cancer_types = cursor.fetchone()[0]
+    if number_cancer_types == 0:
+        eprint('No cancer types in seed database')
+    elif number_cancer_types < 800:
+        # The seed in September 2018 contains 839 cancer types.
+        eprint('Unexpected low number of cancer types in seed database: %s' % number_cancer_types)
+    else:
+        print('Cancer types in seed database: %s' % number_cancer_types)
+
+
+def check_gene_symbols_unique(cursor):
+    """ Check whether the gene symbols are unique."""
+
+    cursor.execute('SELECT HUGO_GENE_SYMBOL FROM cbioportal.gene')
+    gene_symbols = [x[0] for x in cursor.fetchall()]
+    if len(gene_symbols) != len(list(set(gene_symbols))):
+        # Find the duplicate symbols
+        seen = {}
+        duplicates = []
+        for symbol in gene_symbols:
+            if symbol not in seen:
+                seen[symbol] = 1
+            else:
+                if seen[symbol] == 1:
+                    duplicates.append(symbol)
+                seen[symbol] += 1
+        eprint('Gene symbols in HUGO_GENE_SYMBOL column in gene table are not unique:\n%s' % ", ".join(duplicates))
+    else:
+        print('Gene symbols in HUGO_GENE_SYMBOL column in gene table are unique')
+
+
+def check_number_of_studies(cursor):
+    """ Check whether the number of studies is equal to zero."""
+
+    cursor.execute('SELECT count(*) FROM cbioportal.cancer_study')
+    number_studies = cursor.fetchone()[0]
+    if number_studies != 0:
+        eprint('This seed database contains %s studies' % number_studies)
+    else:
+        print('0 studies found in seed database')
+
+
+def check_info_table(cursor):
+    """ Check whether the info table contains 2 values"""
+
+    cursor.execute('SELECT * FROM cbioportal.info')
+    info_values = cursor.fetchall()[0]
+    if not (len(info_values)) == 2:
+        eprint('The "info" table contains other than 2 values: %s' % info_values)
+    if info_values[1] is None or info_values[1] == '':
+        eprint('Missing gene set version in seed database. This is a manual addition to the automated database dump.\n'
+               'See step 6 at https://github.com/cBioPortal/datahub/blob/master/seedDB/Update-Seed-Database.md')
+    else:
+        print('The "info" table is correctly filled.\n'
+              'DB_SCHEMA_VERSION: %s\n'
+              'GENESET_VERSION: %s' % (info_values[0], info_values[1]))
+
+
+def main():
+    # Retrieve the location of the seed
+    seed_location = os.path.join(os.path.dirname(os.getcwd()), check_changed_seed())
+
+    # Start the cbioportal mysql database in a Docker container
+    database = start_mysql_database(seed_location)
+    cursor = database.cursor()
+
+    # Check if gene table not empty
+    check_gene_table(cursor)
+
+    # Check if gene alias table not empty
+    check_gene_alias_table(cursor)
+
+    # Check if cancer type table not empty
+    check_cancer_type_table(cursor)
+
+    # Check whether the hugo gene symbols in the gene table are unique
+    check_gene_symbols_unique(cursor)
+
+    # Check the number of studies, which should be 0
+    check_number_of_studies(cursor)
+
+    # Check the info table for empty values
+    check_info_table(cursor)
+
+
+if __name__ == '__main__':
+    main()

--- a/.circleci/validate_changed_studies.sh
+++ b/.circleci/validate_changed_studies.sh
@@ -41,8 +41,8 @@ if [[ $num_studies > 0 ]]; then
   list_csv=`echo ${list_of_study_dirs[@]} | tr ' ' ','`
   echo $list_csv
 
-  test_reports_location="$HOME/repo/test-reports"
-  validation_command="$HOME/repo/cbioportal/core/src/main/scripts/importer/./validateStudies.py -d $HOME/repo/ -l $list_csv -p $HOME/repo/.circleci/portalinfo -html $test_reports_location"
+  test_reports_location="$HOME/test-reports"
+  validation_command="$HOME/cbioportal/core/src/main/scripts/importer/./validateStudies.py -d $HOME/repo/ -l $list_csv -p $HOME/repo/.circleci/portalinfo -html $test_reports_location"
   echo $'\nExecuting: '; echo $validation_command
   if sh -c "$validation_command" ; then
     echo "Tests passed successfully"

--- a/seedDB/README.md
+++ b/seedDB/README.md
@@ -5,18 +5,16 @@ These files are MySQL database dump files for seeding a new instance of the cBio
 The database schema and cBioPortal release follows different numbering cycles since cBioPortal 1.5.0 and database schema 2.1.0. This means that the version numbers won't be identical. cBioPortal 1.9.0 with database schema 2.4.0 removed PDB annotations from the database.
 
 ## Latest seed database
-#### Seed database schema 2.6.0
+#### Seed database schema 2.7.0
 
 This schema is required for cBioPortal release versions:
-- **1.12.x**
-- **1.13.x**
-- **1.14.0**
+- **1.17.0**
 
-When using a release version **> 1.14.0**, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
+When using a release version **> 1.17.0**, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
 
-**Schema 2.6.0**: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.13.1/db-scripts/src/main/resources/cgds.sql)<br>
-**Seed database**: [seed-cbioportal_hg19_v2.6.0.sql.gz](https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.6.0.sql.gz)<br>
-md5sum aafc9da7b72a29f3978ddca31004b8f5
+**Schema 2.7.0**: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.17.0/db-scripts/src/main/resources/cgds.sql)<br>
+**Seed database**: [seed-cbioportal_hg19_v2.7.0.sql.gz](https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.7.0.sql.gz)<br>
+md5sum 379a76b08f6a0fff51917ddfd78c386a
 
 Contents of seed database:
 - Entrez Gene IDs, HGNC symbols and gene aliases updated in April 2018 from [NCBI](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz)
@@ -26,6 +24,26 @@ Contents of seed database:
 - Cancer Types from OncoTree (fetched July 2018 from http://oncotree.mskcc.org)
 
 ## Previous seed databases
+#### Seed database schema 2.6.0
+
+This schema is required for cBioPortal release versions:
+- 1.12.x
+- 1.13.x
+- 1.14.0
+
+When using a release version > 1.14.0, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
+
+Schema 2.6.0: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.13.1/db-scripts/src/main/resources/cgds.sql)<br>
+Seed database: [seed-cbioportal_hg19_v2.6.0.sql.gz](https://github.com/cBioPortal/datahub/raw/219cf5fc9a553dbc2bfa28a18283087def4a5cf4/seedDB/seed-cbioportal_hg19_v2.6.0.sql.gz)<br>
+md5sum aafc9da7b72a29f3978ddca31004b8f5
+
+Contents of seed database:
+- Entrez Gene IDs, HGNC symbols and gene aliases updated in April 2018 from [NCBI](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz)
+- Gene lengths retrieved from [Gencode Release 27 (mapped to GRCh37)](https://www.gencodegenes.org/releases/27lift37.html)
+- Pfam graphics fetched in August 2017
+- Gene Sets from MSigDB 6.1
+- Cancer Types from OncoTree (fetched July 2018 from http://oncotree.mskcc.org)
+
 #### Seed database schema 2.4.0
 
 This schema is required for cBioPortal release versions:

--- a/seedDB/README.md
+++ b/seedDB/README.md
@@ -5,16 +5,16 @@ These files are MySQL database dump files for seeding a new instance of the cBio
 The database schema and cBioPortal release follows different numbering cycles since cBioPortal 1.5.0 and database schema 2.1.0. This means that the version numbers won't be identical. cBioPortal 1.9.0 with database schema 2.4.0 removed PDB annotations from the database.
 
 ## Latest seed database
-#### Seed database schema 2.7.0
+#### Seed database schema 2.7.2
 
 This schema is required for cBioPortal release versions:
-- **1.17.0**
+- **1.17.2**
 
-When using a release version **> 1.17.0**, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
+When using a release version **> 1.17.2**, a migration step to a new database schema might be required. The migration process is described [here](https://github.com/cBioPortal/cbioportal/blob/master/docs/Updating-your-cBioPortal-installation.md#running-the-migration-script).
 
-**Schema 2.7.0**: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.17.0/db-scripts/src/main/resources/cgds.sql)<br>
-**Seed database**: [seed-cbioportal_hg19_v2.7.0.sql.gz](https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.7.0.sql.gz)<br>
-md5sum 379a76b08f6a0fff51917ddfd78c386a
+**Schema 2.7.2**: [SQL file with create table statements](https://raw.githubusercontent.com/cBioPortal/cbioportal/v1.17.2/db-scripts/src/main/resources/cgds.sql)<br>
+**Seed database**: [seed-cbioportal_hg19_v2.7.2.sql.gz](https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.7.2.sql.gz)<br>
+md5sum b0a4e11b94d00a7291129c30ee4e0f70
 
 Contents of seed database:
 - Entrez Gene IDs, HGNC symbols and gene aliases updated in April 2018 from [NCBI](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz)

--- a/seedDB/Update-Seed-Database.md
+++ b/seedDB/Update-Seed-Database.md
@@ -13,6 +13,7 @@ This documentation file is addressed to developers. To update the seed database 
 
 :warning: Do not confuse the schema version with the cBioPortal version.
 
+Run `mysqldump` to generate the dump files. Make sure you use mysqldump version 5.7.
 ```shell
 mysqldump -u cbio -pP@ssword1 -P 8306 --host 127.0.0.1 --ignore-table cbioportal.pdb_uniprot_alignment --ignore-table cbioportal.pdb_uniprot_residue_mapping --ignore-table cbioportal.info --no-create-info --complete-insert cbioportal > seed-cbioportal_hg19_v2.1.0.sql
 ```

--- a/seedDB/Update-Seed-Database.md
+++ b/seedDB/Update-Seed-Database.md
@@ -13,9 +13,18 @@ This documentation file is addressed to developers. To update the seed database 
 
 :warning: Do not confuse the schema version with the cBioPortal version.
 
-Run `mysqldump` to generate the dump files. Make sure you use mysqldump version 5.7.
+Make sure you use mysqldump version 5.7. When using macOS with homebrew, you can install this by running:
 ```shell
-mysqldump -u cbio -pP@ssword1 -P 8306 --host 127.0.0.1 --ignore-table cbioportal.pdb_uniprot_alignment --ignore-table cbioportal.pdb_uniprot_residue_mapping --ignore-table cbioportal.info --no-create-info --complete-insert cbioportal > seed-cbioportal_hg19_v2.1.0.sql
+brew install mysql@5.7
+
+# Move to 5.7 folder to run this specific mysqldump version
+cd '/usr/local/Cellar/mysql@5.7/5.7.23/bin'
+./mysqldump --version
+```
+
+Run `mysqldump` to generate the dump files:
+```shell
+./mysqldump -u cbio -pP@ssword1 -P 8306 --host 127.0.0.1 --ignore-table cbioportal.pdb_uniprot_alignment --ignore-table cbioportal.pdb_uniprot_residue_mapping --ignore-table cbioportal.info --no-create-info --complete-insert cbioportal > seed-cbioportal_hg19_v2.1.0.sql
 ```
 :warning: The database schema is not included in these dump files.
 


### PR DESCRIPTION
This PR replaces #377 .

# What?
- Update seed database to 2.7.2.
- Print report of contents of the seed database in CircleCI.
- Add CI tests to check for common errors in the seed:
  - Test if a seed database can be loaded with the latest cgds.sql (without migrating).
  - Test whether the seed contains 55000 or more genes
  - Test whether the seed contains 65000 or more gene aliases
  - Test whether the seed contains 800 or more cancer types
  - Test whether the gene symbols in the gene table are unique
  - Test whether there are 0 cancer studies in the seed
  - Test whether the info table is correctly set when loaded.

To test this, first a shell script checks if the seed database file is changed. If it is, docker images are pulled and python requirements are installed. Subsequently, a docker container is started using a mysql 5.7 image, using the latest cgds.sql from cbioportal/master and the changed seed file as entry-points. This is the same way as you would normally start a database for cBioPortal in Docker. Subsequently, MySQL queries are performed to test the data in the database against expected values. 

This test runs on every new PR, and returns without error if the seed database file is not changed.