### PR TITLE
Fix location of error reports when validating all studies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ jobs:
             ./install_dependencies.sh
             ./validate_all_studies.sh
       - store_artifacts:
-          path: test-reports
-          destination: test-reports
+          path: ~/test-reports
+          destination: ~/test-reports
 
   # Job to validate cbioportal.org with cBioPortal Datahub
   validate_datahub_with_cbioportal:


### PR DESCRIPTION
# What?
Fix location of error reports when validating all studies

I tested this in: https://circleci.com/gh/cBioPortal/datahub/895