### PR TITLE
stad_tcga_pub: removed extra 76 samples that were not in the publication

### DIFF
--- a/public/stad_tcga_pub/data_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/stad_tcga_pub/data_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a1cf780ee3d487e6ff06dbaa6b0f7c5324ac06104f54e7d67c0c1dd945cab26
-size 50458883


### PR DESCRIPTION
# What?
Fix issue #https://github.com/cBioPortal/datahub/issues/660

Cancer studies updated in this pull request:
- stad_tcga_pub
