### PR TITLE
Datafix

### DIFF
--- a/public/coad_cptac_2019/data_mutations_extended.txt
+++ b/public/coad_cptac_2019/data_mutations_extended.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:534970c54a46f5291f46db9248873dcfbc323418181b1411dd3956d181b7932d
+size 186575084

--- a/public/coad_cptac_2019/data_mutations_mskcc.txt
+++ b/public/coad_cptac_2019/data_mutations_mskcc.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe950a1712ee1a8f28c0533906e7860d6d181c55cb2629f69506556595105549
+size 186610556

--- a/public/coad_cptac_2019/meta_mutations_extended.txt
+++ b/public/coad_cptac_2019/meta_mutations_extended.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: coad_cptac_2019
+genetic_alteration_type: MUTATION_EXTENDED
+datatype: MAF
+stable_id: mutations
+show_profile_in_analysis_tab: true
+profile_description: Mutation data from whole exome sequencing.
+profile_name: Mutations
+data_filename: data_mutations_extended.txt


### PR DESCRIPTION
# What?
Fix # .

Cancer studies updated in this pull request:
- a
- .

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

