### PR TITLE
update no_output_timeout parameter to 1hr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             cd ~/repo/.circleci
             ./install_dependencies.sh
             ./validate_changed_studies.sh
-          no_output_timeout: 30m
+          no_output_timeout: 1h
       - store_artifacts:
           path: ~/test-reports
           destination: ~/test-reports
@@ -36,7 +36,7 @@ jobs:
             cd ~/repo/.circleci
             ./install_dependencies.sh
             ./validate_all_studies.sh
-          no_output_timeout: 30m
+          no_output_timeout: 1h
       - store_artifacts:
           path: ~/test-reports
           destination: ~/test-reports


### PR DESCRIPTION
acc_2019 validation on circleci is running for more than 30min. 