### PR TITLE
stes_tcga_pub: added missing CNA data for 90 samples

### DIFF
--- a/public/stes_tcga_pub/data_CNA.txt
+++ b/public/stes_tcga_pub/data_CNA.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4b596ec2a83ef85cd6be9f1de0acfad6dfefa06b8679ff481be7c2a6a953284
-size 21360671
+oid sha256:8f2a8b12d24795bea0d5a22545c439e6de5cba433884fbd8f349b1ab740b000a
+size 21360683

--- a/public/stes_tcga_pub/data_CNA.txt
+++ b/public/stes_tcga_pub/data_CNA.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0ea290b170b3ad8254ac1ae423abcfda408f065545b5a5910b8ffa9f9f2e368
-size 16390173
+oid sha256:e4b596ec2a83ef85cd6be9f1de0acfad6dfefa06b8679ff481be7c2a6a953284
+size 21360671


### PR DESCRIPTION
Cancer studies updated in this pull request:
- stes_tcga_pub
