### PR TITLE
prad_eururol_2017: Update all file format to `Unix LF`

### DIFF
--- a/public/prad_eururol_2017/data_clinical_patient.txt
+++ b/public/prad_eururol_2017/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3514c8b9c94a6355389ef6740d2545671a6aedc1f6deb93c487911c4ac30c1f
-size 4475
+oid sha256:0030b29a79054a61455a0e423d34cef663e2ee82be80d9d4897781e1caffd788
+size 4473

--- a/public/prad_eururol_2017/data_mRNA_seq_fpkm.txt
+++ b/public/prad_eururol_2017/data_mRNA_seq_fpkm.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bfda60dae51bb44c028b7b5f03d78fbcc61d8afc50f7ef7566beeece7e8d272
+oid sha256:db92ab784e31a2f9a5b9afb409b27acf1454fef33da86ba0144d07b9ba60d982
 size 11590293


### PR DESCRIPTION
# What?
Fix file format (to `Unix LF`) 

Cancer studies updated in this pull request:
- prad_eururol_2017


