### PR TITLE
import treatment data as generic_assay data type

### DIFF
--- a/public/ccle_broad_2019/data_drug_treatment_AUC.txt
+++ b/public/ccle_broad_2019/data_drug_treatment_AUC.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6cf88144575eeeb0aea505e0ab06ceffc8ca85292760f8b00c2be96c6e4e93e
-size 2232845
+oid sha256:f724c07a2a08a6325b1ece0c2e2abf5e69cd0670d2c40603eca1888f88df47c3
+size 2232830

--- a/public/ccle_broad_2019/data_drug_treatment_IC50.txt
+++ b/public/ccle_broad_2019/data_drug_treatment_IC50.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf115c87034d7be2b5303629e77d53b832e2dfb27cb6e0d864ffe98b6da66e8d
-size 4084916
+oid sha256:a2ce2d9aa2141469284cd4a94a2880edcdc5846b089403f1c51786bcbbc042ec
+size 4084901

--- a/public/ccle_broad_2019/data_drug_treatment_ZSCORE.txt
+++ b/public/ccle_broad_2019/data_drug_treatment_ZSCORE.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5dc65818a2f519f7f8961a0c276a800eec90e68787ff8b4ebdbbd1586f293dc
-size 2340931
+oid sha256:ebcb7a3af20ccf60d07a97eae89a2a2334a4d05613b4b003542ac8e879235b72
+size 2340916

--- a/public/ccle_broad_2019/meta_drug_treatment_AUC.txt
+++ b/public/ccle_broad_2019/meta_drug_treatment_AUC.txt
@@ -1,11 +1,12 @@
 cancer_study_identifier: ccle_broad_2019
 genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: TREATMENT_RESPONSE
 datatype: LIMIT-VALUE
 stable_id: CCLE_drug_treatment_AUC
 profile_name: Treatment response: AUC
 profile_description: Area under the sigmoidal curve, derived from fitting the drug screening tests to a mixed-effects model (Vis et al. 2016).
-data_filename: data_ZSCORE.txt
 data_filename: data_drug_treatment_AUC.txt
 show_profile_in_analysis_tab: true
 pivot_threshold_value: 0
 value_sort_order: ASC
+generic_entity_meta_properties: NAME,URL,DESCRIPTION

--- a/public/ccle_broad_2019/meta_drug_treatment_IC50.txt
+++ b/public/ccle_broad_2019/meta_drug_treatment_IC50.txt
@@ -1,5 +1,6 @@
 cancer_study_identifier: ccle_broad_2019
 genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: TREATMENT_RESPONSE
 datatype: LIMIT-VALUE
 stable_id: CCLE_drug_treatment_IC50
 profile_name: Treatment response: IC50
@@ -8,3 +9,4 @@ data_filename: data_drug_treatment_IC50.txt
 show_profile_in_analysis_tab: true
 pivot_threshold_value: 0.000001
 value_sort_order: ASC
+generic_entity_meta_properties: NAME,URL,DESCRIPTION

--- a/public/ccle_broad_2019/meta_drug_treatment_ZSCORE.txt
+++ b/public/ccle_broad_2019/meta_drug_treatment_ZSCORE.txt
@@ -1,5 +1,6 @@
 cancer_study_identifier: ccle_broad_2019
 genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: TREATMENT_RESPONSE
 datatype: LIMIT-VALUE
 stable_id: CCLE_drug_treatment_zscore
 profile_name: Treatment response: Z-score of IC50
@@ -8,3 +9,4 @@ data_filename: data_drug_treatment_ZSCORE.txt
 show_profile_in_analysis_tab: true
 pivot_threshold_value: 0
 value_sort_order: ASC
+generic_entity_meta_properties: NAME,URL,DESCRIPTION


### PR DESCRIPTION
the third step of https://github.com/cBioPortal/cbioportal/issues/6769.

In this pull request, changed the [data format](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#generic-assay) of `TREATMENT_RESPONSE` data to fit `GENERIC_ASSAY` data format in `ccle_broad_2019` study.