### PR TITLE
coadread_mskcc: added gene matrix

### DIFF
--- a/public/coadread_mskcc/data_gene_matrix.txt
+++ b/public/coadread_mskcc/data_gene_matrix.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aac0422c3d08f6b2b1ac96d3ae1e0b789cac805427d25c1902231bb9ad14aff9
-size 4025
+oid sha256:16813986e9fc0f568b9b76ca246b72b7d3e770be2814f3b8b9598810749b2131
+size 2641

--- a/public/coadread_mskcc/data_gene_matrix.txt
+++ b/public/coadread_mskcc/data_gene_matrix.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aac0422c3d08f6b2b1ac96d3ae1e0b789cac805427d25c1902231bb9ad14aff9
+size 4025

--- a/public/coadread_mskcc/meta_gene_matrix.txt
+++ b/public/coadread_mskcc/meta_gene_matrix.txt
@@ -1,0 +1,4 @@
+cancer_study_identifier: coadread_mskcc
+genetic_alteration_type: GENE_PANEL_MATRIX
+datatype: GENE_PANEL_MATRIX
+data_filename: data_gene_matrix.txt


### PR DESCRIPTION
# What?
added gene matrix for coadread_mskcc

Cancer studies updated in this pull request:
- coadread_mskcc

*assumed the samples are sequenced with panel IMPACT230 based on this line in the paper:
"We performed deep sequencing of 230 cancer-associated genes in 69 primary CRC tumors and matched metastases to define the mutational concordance of these genes in primary and metastatic tumors" and also this is an old study (2014)