### PR TITLE
histiocytosis_cobi_msk_2019: added gene matrix

### DIFF
--- a/public/histiocytosis_cobi_msk_2019/data_gene_matrix.txt
+++ b/public/histiocytosis_cobi_msk_2019/data_gene_matrix.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8648509d3161a9b47bcffd7de36d68b6d2dc6efb6c7a84bdc63fbf153680e134
-size 1581
+oid sha256:e4080eab950ce1216192ea388079062122f1cdf37dc6a1949ad3f08012259388
+size 1551

--- a/public/histiocytosis_cobi_msk_2019/data_gene_matrix.txt
+++ b/public/histiocytosis_cobi_msk_2019/data_gene_matrix.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8648509d3161a9b47bcffd7de36d68b6d2dc6efb6c7a84bdc63fbf153680e134
+size 1581

--- a/public/histiocytosis_cobi_msk_2019/meta_gene_matrix.txt
+++ b/public/histiocytosis_cobi_msk_2019/meta_gene_matrix.txt
@@ -1,0 +1,4 @@
+cancer_study_identifier: histiocytosis_cobi_msk_2019
+genetic_alteration_type: GENE_PANEL_MATRIX
+datatype: GENE_PANEL_MATRIX
+data_filename: data_gene_matrix.txt


### PR DESCRIPTION
# What?
histiocytosis_cobi_msk_2019: added gene matrix

Cancer studies updated in this pull request:
- histiocytosis_cobi_msk_2019

Unable to identify panels for samples listed below:
- (impact)
P-0004770-T03-IM5, P-0001360-T01-IM3
- (archer/raindance)
P-0008055-T03-TS1
P-0012544-T02-TS1
P-0012544-T03-TS1
P-0004770-T04-TS1
P-0015144-T02-TS1
P-0019478-T01-AH1
P-0015144-T01-AH1
- (sample ID doesn't match to any DMP ID)
P-0001219	SAMPLE-14


