### PR TITLE
fixes to gene panel files

### DIFF
--- a/reference_data/gene_panels/data_gene_panel_bcc_unige_2016_cancer_panel.txt
+++ b/reference_data/gene_panels/data_gene_panel_bcc_unige_2016_cancer_panel.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:feae9835239f7ff9d84bfb8db7976ea0616e357773383a942a629e9732d9a4fe
-size 2382
+oid sha256:4afd9f62a106a2753221a2cacfac8fc9e62269753358e13eb0308f31f8a94ff6
+size 2387

--- a/reference_data/gene_panels/data_gene_panel_fmi_t5a.txt
+++ b/reference_data/gene_panels/data_gene_panel_fmi_t5a.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fe721a50c9dc7b229cc946b87a165d888fdebe05428d8e90b6729c952abb2d9
-size 1994
+oid sha256:6cd009c0e417d49b62f44e0e407fef9156fc42b383c9deac1d5e9a513f2929e8
+size 1993

--- a/reference_data/gene_panels/data_gene_panel_prad_mskcc_sequenom_sanger.txt
+++ b/reference_data/gene_panels/data_gene_panel_prad_mskcc_sequenom_sanger.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3bbc0aab717716280bdfb5535c0e2141beebd4e8786121490b8fbf105d7f3383
-size 1003
+oid sha256:e12cdcdbf30ab8b05c26651bf12db054c229cee84fd13b46df44c46be52ab188
+size 1004


### PR DESCRIPTION
# What?
Fixes to gene panel files
- drop trailing space in stable_id
- remove description text from stable_id
- add space after colon to match style

Cancer studies updated in this pull request:
None

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

