### PR TITLE
prad_mskcc: rolled back zscore data and meta files to the old method

### DIFF
--- a/public/prad_mskcc/data_mRNA_median_Zscores.txt
+++ b/public/prad_mskcc/data_mRNA_median_Zscores.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd48e06f8612872f46c8a5c49c2e904cb19892946c3dee54aada4100ac2b34a0
-size 30721007
+oid sha256:ea24ea8e0c8944d88b1b0c7ad201f47889af78ea1c25a39b906e581f627e4a50
+size 49243686

--- a/public/prad_mskcc/meta_mRNA_median_Zscores.txt
+++ b/public/prad_mskcc/meta_mRNA_median_Zscores.txt
@@ -1,7 +1,7 @@
 cancer_study_identifier: prad_mskcc
 stable_id: mrna_zbynorm
 profile_name: mRNA Expression Z-Scores vs Normals
-profile_description: mRNA Z-Scores compared to expression in all tumor samples.
+profile_description: mRNA Z-Scores compared to expression in normal prostate samples
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt


### PR DESCRIPTION
Cancer studies updated in this pull request:
- prad_mskcc

