### PR TITLE
TCGA Firehose Legacy: added new z-score profiles (all sample reference)

### DIFF
--- a/public/acc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/acc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eed71d69dc11a2b49a655831a75e4b1670e78eb79dbd90a10f4d8e7f7a44825
+size 12030105

--- a/public/acc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/acc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/acc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/acc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: acc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/blca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4fbe46c4df69dee501b212f1f9679e4ecaf57b128dcb9bcaadfd9d397a6dba6
+size 62188143

--- a/public/blca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/blca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/blca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: blca_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f19bcb6144207f56f6a7190b6f452efde6d266493d888b225d267e2c56b42d3b
+size 167291922

--- a/public/brca_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87859f5d17e2dd9d39da614f949a7e8d47f5d1c01556aa169c0ec0a21ca15525
+size 71598054

--- a/public/brca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/brca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/brca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: brca_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/brca_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/brca_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: brca_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/cesc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/cesc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bf7755f531608e88ac8839ba514568e8a4a7e0252db52194ff684596b68eb43
+size 46461730

--- a/public/cesc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/cesc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/cesc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/cesc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: cesc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/chol_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/chol_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adcce2f02a2fd084d1cc848c482c155c5afe493c9788b6c5b93b99efdbd5da37
+size 5579556

--- a/public/chol_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/chol_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/chol_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/chol_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: chol_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad40258d2b5ea17a3ca372239847cd7ff0586b4fda4989bea78c6eb4d5d23048
+size 57816907

--- a/public/coadread_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:440537041d4b489084f42f45dbd35c593ee7b4e609fef1791fe42482837f3b3a
+size 29380692

--- a/public/coadread_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/coadread_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/coadread_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: coadread_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/coadread_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/coadread_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: coadread_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/dlbc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/dlbc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77383fec169c002e44d79ef736ab8a5df78dc7fbbbedd451964d1371ac674c4f
+size 7470063

--- a/public/dlbc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/dlbc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/dlbc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/dlbc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: dlbc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/esca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/esca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079f5e293c1bcccb32cc1d793e5266ea8e934fe09c337d4405a9221edfa8aeff
+size 28360869

--- a/public/esca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/esca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/esca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/esca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: esca_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12d33c56a9a0a1d0ba37ba0046303df381f8ee4b5b9bac61c194612ff8c7b7a6
+size 25146383

--- a/public/gbm_tcga/data_expression_all_sample_Zscores.txt
+++ b/public/gbm_tcga/data_expression_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fccfb593de956f33206752aa9948ea3c11d84a28bb1de1078c90493917c0443
+size 47207276

--- a/public/gbm_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22c702576aa9ed596a5e74c56458f7ab11e58172f6eca136166dd6035eae1abc
+size 53376350

--- a/public/gbm_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/gbm_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,6 +4,6 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)
 source_stable_id: rna_seq_v2_mrna

--- a/public/gbm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: gbm_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_tcga/meta_expression_Zscores.txt
+++ b/public/gbm_tcga/meta_expression_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_expression_Zscores.txt
 stable_id: mrna_U133_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores  (U133 microarray only) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (U133 microarray only)
+profile_description: mRNA expression z-scores (U133 microarray only) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (U133 microarray only)

--- a/public/gbm_tcga/meta_expression_all_sample_Zscores.txt
+++ b/public/gbm_tcga/meta_expression_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: gbm_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_U133_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (U133 microarray only)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (U133 microarray only).
+data_filename: data_expression_all_sample_Zscores.txt

--- a/public/gbm_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/gbm_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/gbm_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: gbm_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/hnsc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/hnsc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46f5917faf94763fe2bf5d588fc3d7e6e032bb46d2730a4dc0fcef50514be503
+size 79542353

--- a/public/hnsc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/hnsc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/hnsc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/hnsc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: hnsc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:900633808cc055066dd23950b5668bf2295399491a97f0efb2c9fc6e992212fe
+size 10063359

--- a/public/kich_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/kich_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/kich_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kich_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c9530b3348caadc2a14bd0380c1cab917fb5a6df46956ff2a4529253e87a56a
+size 81283960

--- a/public/kirc_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb04f5cb62b748ca34d6d334766a7f737df7e27f6ee1196fcc73ef526820b033
+size 9305618

--- a/public/kirc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/kirc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/kirc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kirc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirc_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/kirc_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/kirc_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kirc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/kirp_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0352dc2b90621a0f0d79d45b8bd98ea75405e7fc0db7878a501d87468d981cdf
+size 44324645

--- a/public/kirp_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94d6c2da1e0e3ee0fb8a1b20aa1127fe4f413021858abb50af4d6ff6f7baf62d
+size 2093658

--- a/public/kirp_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/kirp_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/kirp_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kirp_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirp_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/kirp_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/kirp_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kirp_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/laml_tcga/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44315be91f7636838c8d3edc3f8378f7f18ea5d4b03290d3c7895ffce3be382d
+size 26473138

--- a/public/laml_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a53a314664c2fe8f477e8a75bf28344443a239da1517a9092f14785b70cdcf73
+size 26167994

--- a/public/laml_tcga/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: laml_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq RPKM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/laml_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/laml_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/laml_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: laml_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lgg_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:934afef315688bd7f123191bb6dfdbccafe2049df58f2ba0d5c0e79bb665e9e5
+size 80545335

--- a/public/lgg_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a295e617fdbaf8ab7365d9f25084e724cd906a1acc93cc1ad68f0fce1dcd382
+size 3322710

--- a/public/lgg_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/lgg_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/lgg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lgg_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lgg_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/lgg_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/lgg_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lgg_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/lihc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lihc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9194109e71bf51bfee526f45a492cd5fc18a965590159a185f57ee978cd25dec
+size 56699620

--- a/public/lihc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/lihc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/lihc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lihc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lihc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/luad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd9281bf2a6c108e37a81ac5b13ce2fd08ee4a37c2232210d1ec372380dcc4d3
+size 78504018

--- a/public/luad_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4183f72fd40ed2e65336ef2c037021475cf9f3745d810b08e2bf9dc9eb62d7d5
+size 4197411

--- a/public/luad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/luad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/luad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: luad_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/luad_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/luad_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/luad_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: luad_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/lusc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:840160ddaf799d933b4adb9e6436c51559531e5b92914751022378778116e888
+size 76196436

--- a/public/lusc_tcga/data_expression_all_sample_Zscores.txt
+++ b/public/lusc_tcga/data_expression_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eb88e7d8dd7f16b1e916ec5faad91d7565bc297209636c3ff1e1e84f237fea3
+size 12001121

--- a/public/lusc_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68dbbc243862e93f663da90a3c2882ed12962ca9ce58e5da9807bbdd98d9ae89
+size 20854437

--- a/public/lusc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/lusc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/lusc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lusc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lusc_tcga/meta_expression_Zscores.txt
+++ b/public/lusc_tcga/meta_expression_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_expression_Zscores.txt
 stable_id: mrna_U133_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores  (U133 microarray only) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (U133 microarray only)
+profile_description: mRNA expression z-scores (U133 microarray only) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (U133 microarray only)

--- a/public/lusc_tcga/meta_expression_all_sample_Zscores.txt
+++ b/public/lusc_tcga/meta_expression_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lusc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_U133_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (U133 microarray only)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (U133 microarray only).
+data_filename: data_expression_all_sample_Zscores.txt

--- a/public/lusc_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/lusc_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/lusc_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lusc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/meso_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/meso_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c20dbd4d3d2826dcadbb6c928e0d73c56ea072d5ee168843933a35efe110f7fb
+size 13292862

--- a/public/meso_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/meso_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/meso_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/meso_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: meso_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ov_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb5b2acb2db398ef12ca7df14a04b531ca792f4b3175df1497607b7d48574bdc
+size 46676556

--- a/public/ov_tcga/data_expression_all_sample_Zscores.txt
+++ b/public/ov_tcga/data_expression_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88b81aafd5b438c5aa917ec037898eb3868a6b88a48c83393e92c6b3754a2222
+size 47874526

--- a/public/ov_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21d72d47fadaa37cfb1373a412ecd43c39e055184dc2fba86884de47b9d79ff1
+size 75645851

--- a/public/ov_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/ov_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/ov_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ov_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ov_tcga/meta_expression_Zscores.txt
+++ b/public/ov_tcga/meta_expression_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_expression_Zscores.txt
 stable_id: mrna_U133_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores  (U133 microarray only) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (U133 microarray only)
+profile_description: mRNA expression z-scores (U133 microarray only) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (U133 microarray only)

--- a/public/ov_tcga/meta_expression_all_sample_Zscores.txt
+++ b/public/ov_tcga/meta_expression_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ov_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_U133_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (U133 microarray only)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (U133 microarray only).
+data_filename: data_expression_all_sample_Zscores.txt

--- a/public/ov_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/ov_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/ov_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ov_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/paad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/paad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dacc663f52018c34db0a6cd4f4c5156dc646c5b67ae99bfb865a6b53271f09b2
+size 27117483

--- a/public/paad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/paad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/paad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/paad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: paad_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/pcpg_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/pcpg_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a52922f863a614cda2920e32321c76d0ba47b1f27a2c6fd3f8c81954a52299b
+size 27895502

--- a/public/pcpg_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/pcpg_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/pcpg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/pcpg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: pcpg_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/prad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/prad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4638424f59378f967867e4ab4bdfbf3b47ff4ea0fc0c3389618225b5257d752e
+size 75607301

--- a/public/prad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/prad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/prad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/prad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: prad_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/sarc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/sarc_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dc5bceccf3e466b6505d8a8e3ff9210f88e73d565176463e6d7212c0891f628
+size 40181646

--- a/public/sarc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/sarc_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/sarc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/sarc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: sarc_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/skcm_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/skcm_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:843db34ca471217e95d3a738e2447af6ac53d9a6f91dc01f6fa04567f07efe73
+size 71907385

--- a/public/skcm_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/skcm_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/skcm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/skcm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: skcm_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/stad_tcga/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b63d530c120dc984d805c09fb81c9b686d3f5465328d087babef4fd92081594
+size 6157944

--- a/public/stad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919125c6861b2d5077bb05379c0044bc3764027e79f899263ccc9a779a2c9b4d
+size 63332595

--- a/public/stad_tcga/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: stad_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq RPKM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/stad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/stad_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/stad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: stad_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/tgct_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/tgct_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93810ae16654f94de77e88a1e573d65863021d14dce1e1aac1ca0084bf1df6c9
+size 23788441

--- a/public/tgct_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/tgct_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/tgct_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/tgct_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: tgct_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thca_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00352afe18148f66a453395166ddba33406b26f13ad82d2067428d63b3f77b7
+size 77139255

--- a/public/thca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/thca_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/thca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: thca_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thym_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thym_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0d2251f4948a8ba5fa9c735c988a87fa268999833caf97a7a5b48ccb87cef9c
+size 18256024

--- a/public/thym_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/thym_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/thym_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thym_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: thym_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucec_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b72deafd0c53de3e56b70fff713c6aa778afce3df5220722dc62d4023d96e0c5
+size 26974829

--- a/public/ucec_tcga/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51f2ebc147d18ebdd13fd526cdeb4903712934b20b8d8958894f827e4d1530a8
+size 7294177

--- a/public/ucec_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/ucec_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/ucec_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ucec_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucec_tcga/meta_mRNA_median_Zscores.txt
+++ b/public/ucec_tcga/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_mRNA_median_Zscores.txt
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA expression z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)

--- a/public/ucec_tcga/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ucec_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (microarray)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples  (Agilent microarray).
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/ucs_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucs_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d98958b693aef9db4df1a2f29cfe3994e960794f7009c1b9891d97498e7c312a
+size 8793484

--- a/public/ucs_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/ucs_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/ucs_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucs_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ucs_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/uvm_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/uvm_tcga/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14ca5040f007efac49c47ee8c4763998ee85d6e9078e521c08f50cbca33c8ec6
+size 12067338

--- a/public/uvm_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/uvm_tcga/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/uvm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/uvm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: uvm_tcga
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt


### PR DESCRIPTION
Cancer studies updated in this pull request:
- Added new log-transformed expression z-score profiles with the reference population of all samples to TCGA firehose legacy studies.
- Updated the existing diploid sample reference z-score profile names and descriptions. 

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

