### PR TITLE
TCGA pancan studies: added all sample reference z-score profiles

### DIFF
--- a/public/acc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd8359222ed0cbf28ce452f7883021a3daae350f30d5a316076a2bc392fc269
+size 11868506

--- a/public/acc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/acc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/blca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae709d4dee597bf952badea110114b1d93819013b81c63eeddfd62810c1142e0
+size 62025131

--- a/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: blca_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8b810a7bd5a38e3af2f845eeeda5abab2fb366f7e268193a4f1169d376c5338
+size 164544535

--- a/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: brca_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/cesc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/cesc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:438abf5dd9ab59a8007206b705cee2b64550136b5db21335bf60639771f4b65a
+size 44637380

--- a/public/cesc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/cesc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/cesc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/cesc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: cesc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/chol_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/chol_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8357934e3dd7ba24d375678edc3bb0ba5f7cfde649ab2027f154d4abc85be814
+size 5572132

--- a/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: chol_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebdc7070821e4da7da307224ab163e5dcf973d268914c6450c8b3f2621cefd78
+size 86679612

--- a/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: coadread_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/dlbc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/dlbc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c9627ec9e962c86372adba7bb3a1b68a944b04a1af84c184c68a388b9ca05d6
+size 7462620

--- a/public/dlbc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/dlbc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/dlbc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/dlbc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: dlbc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/esca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/esca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69e3837ea3853ee72ce1158c75649ed49f9207050476e986de5b970457b029c9
+size 26698719

--- a/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: esca_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a683b931206cb72c9232d96829004a96b7fb4938a065832e87eecfb00c09c7d
+size 24228731

--- a/public/gbm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/gbm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/gbm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: gbm_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/hnsc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/hnsc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1002a5dc5e084470cdab5b96dbdc04cb2c9a19dad7ae349d9ab820fca10261b
+size 78476773

--- a/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: hnsc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e191efd3cef0beddb39a48a11980a63a82aff11730e6b254560ce8d8ba55045
+size 9903400

--- a/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kich_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af624c1882df6dff151049b8bac09f6da0051dfc5205864acc9e6282d207338
+size 77622849

--- a/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kirc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirp_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9045ccca347a2cfb37f23087cd49e43cca1b6b357cbbc9b76a90f908dbdc460e
+size 43117310

--- a/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kirp_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/laml_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e2e9188bee9ffa2ec0c3f69606c2705d3e09c4210646cfd31c436e787fc1241
+size 23685416

--- a/public/laml_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/laml_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/laml_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: laml_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lgg_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7b01ffa556d60b5b16bf81f175354f25630f955dc8043a966fa4ff877aa0cb2
+size 78102802

--- a/public/lgg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/lgg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/lgg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lgg_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lihc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lihc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e3c163edce8aa6ddf6bb356cf69541f5e54070d70bf5be7743e59c5fadf6f09
+size 55630274

--- a/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lihc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/luad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a3e8de7ee472a4edb141b4deed405f23761a1864ac2afd48f223e384e6d23c1
+size 77426558

--- a/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: luad_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lusc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3294ac76ef91922b605ff03c929b9da3bf85ba88e8cc0c7f7b1f6c0d1943faf
+size 73613859

--- a/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: lusc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/meso_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/meso_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e44becb7a6d45a8743251d74fa337448e7348d723c958382d798ef472fffdc
+size 13285514

--- a/public/meso_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/meso_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/meso_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/meso_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: meso_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ov_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eebd833c2701b0bcd057bf82ce7350accd0660ac8193a13fe74530f591a704cf
+size 44052111

--- a/public/ov_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/ov_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/ov_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ov_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/paad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/paad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a480debac25f7f3b4fb27e2b283badc18e18ee15437e0f81d7399a43e7f4cb29
+size 26809995

--- a/public/paad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/paad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/paad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/paad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: paad_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/pcpg_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/pcpg_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5de603614545488f830d6b98c7b4684887c7467b4d8ea031d4ea8cc6edb1e85
+size 26983205

--- a/public/pcpg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/pcpg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/pcpg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/pcpg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: pcpg_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/prad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/prad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61f4f3fbfd93850181f0165973c916f7afabcae9c9061b1861ecac848ea24a84
+size 74621750

--- a/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: prad_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/sarc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/sarc_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ffa97ad72cf791e790bdf6c5f4aa822bac8bd3759d1400d1bd754c239739254
+size 38659377

--- a/public/sarc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/sarc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/sarc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/sarc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: sarc_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/skcm_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f25d8fef3c255021a73da9709cc4d1d9e4f423333b8ac91781f4bde3f8e25a39
+size 67482802

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/stad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c3b4ecbd918cfe25b26209dbe4099c589e17664ab44f03965e41a3327040e0
+size 60017796

--- a/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: stad_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/tgct_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/tgct_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc300b8881eec375485d3b151a473d729c52eed9709a8dc0fc34669bba4f4df4
+size 22725688

--- a/public/tgct_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/tgct_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/tgct_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/tgct_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: tgct_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thca_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0867c90f2c4d147ba53d6d566c4dd0c0ef1f66712af8b72856be2bc26f27d46f
+size 75461922

--- a/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: thca_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thym_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thym_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48fe51526a61155b18599bce0dde48ffbdaddcf3313f074a41a21eead9e4c7ff
+size 18098669

--- a/public/thym_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/thym_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/thym_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thym_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: thym_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucec_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12271d1535186f858eb1b486184ae002b93edb5fc9409493c151e04838d5168f
+size 75439874

--- a/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ucec_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucs_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucs_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9aff46762ffa8c21e07dc007d111b90af5bfeda4a5a4230357521c070da24a94
+size 8786065

--- a/public/ucs_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/ucs_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/ucs_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucs_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: ucs_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/uvm_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/uvm_tcga_pan_can_atlas_2018/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60214a22108e6a583293eae2d4b97c52cffc82c07a84fe14dc0348e0be32d093
+size 12059860

--- a/public/uvm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/uvm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_description:mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
-profile_name: mRNA Expression Zscores, RSEM (Batch normalized from Illumina HiSeq_RNASeqV2)
+profile_description: mRNA expression z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)

--- a/public/uvm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/uvm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: uvm_tcga_pan_can_atlas_2018
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: TRUE
+profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt


### PR DESCRIPTION
Cancer studies updated in this pull request:
- Added new log-transformed expression z-score profiles with the reference population of all samples to all TCGA pancan studies.
- Updated the existing diploid sample reference z-score profile names and descriptions.

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

