### PR TITLE
utuc_msk_2019: Added missing Age and Race category for some patients

### DIFF
--- a/public/utuc_msk_2019/data_clinical_patient.txt
+++ b/public/utuc_msk_2019/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33d7917d4855b73c6da3215952cc5a8aa331b766653a46d838491bfa9e78701d
-size 4546
+oid sha256:cdbea1c127d248350949feb6e35a58263a0d40c4d0e6df17c6d681fbc571d7bd
+size 4816


### PR DESCRIPTION
Cancer studies updated in this pull request:
- utuc_msk_2019

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

