### PR TITLE
TCGA pancan & firehose legacy studies: updated all sample zscore profile names

### DIFF
--- a/public/acc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/acc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/acc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/blca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/cesc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/cesc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/cesc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/cesc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/chol_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/chol_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/dlbc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/dlbc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/dlbc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/dlbc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/esca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/esca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/hnsc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/hnsc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirp_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/laml_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/laml_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/laml_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lgg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lgg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lgg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lihc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lihc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/luad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lusc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/meso_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/meso_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/meso_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/meso_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ov_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ov_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ov_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/paad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/paad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/paad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/paad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/pcpg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/pcpg_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/pcpg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/pcpg_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/prad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/prad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/sarc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/sarc_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/sarc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/sarc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/skcm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/skcm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/stad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/tgct_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/tgct_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/tgct_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/tgct_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thca_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thym_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thym_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/thym_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/thym_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucec_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucs_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucs_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/ucs_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/ucs_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/uvm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/uvm_tcga/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/uvm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/uvm_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: TRUE
-profile_name: mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
 profile_description: Log-transformed mRNA expression z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt


### PR DESCRIPTION
# What?
Updated the profile names to indicate log transformation. Example
` mRNA expression z-scores relative to all samples (RNA Seq V2 RSEM)`
is changed to
` mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)`

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

