### PR TITLE
brca_tcga_pub2015: added missing diploid zscore profiles

### DIFF
--- a/public/brca_tcga_pub2015/data_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/data_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dd307e8ead75c2873955160be4922c2faf12d796599343d9048e89c39d18349
+size 122806013

--- a/public/brca_tcga_pub2015/data_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/data_mRNA_median_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec0fc37e973ccf06da24ad32cd0f2316d5dadc65d9c5e39ecf7c21281c0725df
+size 54091707

--- a/public/brca_tcga_pub2015/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: brca_tcga_pub2015
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_Zscores
+show_profile_in_analysis_tab: true
+profile_description: mRNA z-scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (RNA Seq V2 RSEM)
+data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt

--- a/public/brca_tcga_pub2015/meta_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub2015/meta_mRNA_median_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: brca_tcga_pub2015
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_Zscores
+show_profile_in_analysis_tab: true
+profile_description: mRNA z-scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores relative to diploid samples (microarray)
+data_filename: data_mRNA_median_Zscores.txt


### PR DESCRIPTION
# What?
related issue #1068 (do not want to close the card yet until the end of scrum for review of work)

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

