### PR TITLE
Mutated Issue Fix: prad_mskcc_cheny1_organoids_2014, sclc_ucologne_2015

### DIFF
--- a/public/prad_mskcc_cheny1_organoids_2014/data_mutations_extended.txt
+++ b/public/prad_mskcc_cheny1_organoids_2014/data_mutations_extended.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f62174228c67e7e74faa3f8949ac5256d4dc7038ee82586520e16d320942b1e2
-size 151381
+oid sha256:cbebd5d6e1ad1e719d82bd19af6c1b02301570611eed97ce3d52f3947ef2565d
+size 219047

--- a/public/prad_mskcc_cheny1_organoids_2014/data_mutations_mskcc.txt
+++ b/public/prad_mskcc_cheny1_organoids_2014/data_mutations_mskcc.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9334abc051b8d49b777ee9b474b75d28aabdb5ff3d769fbdd211fd41f0d8c99
-size 151383
+oid sha256:cbebd5d6e1ad1e719d82bd19af6c1b02301570611eed97ce3d52f3947ef2565d
+size 219047

--- a/public/sclc_ucologne_2015/data_mutations_extended.txt
+++ b/public/sclc_ucologne_2015/data_mutations_extended.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35dd659871f4a96268b4ff7d2c8b8e671e7dfd9edc3686b2fe9cfdd07356d20f
-size 8183501
+oid sha256:b48c8eb5845e6435c1e1814daede7a8e171039fdc993d30cd054b9c543f40c91
+size 8183689

--- a/public/sclc_ucologne_2015/data_mutations_mskcc.txt
+++ b/public/sclc_ucologne_2015/data_mutations_mskcc.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eced968a77a582eb35f04313c35e19c2d2d763e0ebb295d7c8a70a24ec9938bb
-size 8202135
+oid sha256:b48c8eb5845e6435c1e1814daede7a8e171039fdc993d30cd054b9c543f40c91
+size 8183689


### PR DESCRIPTION
# What?
Fix #114

# Cancer studies updated in this pull request:
- prad_mskcc_cheny1_organoids_2014_mutations: 707 failed rows originally
- sclc_ucologne_2015_mutations: 3 failed rows originally

# QC steps
- check line counts (should be the same, use `wc -l file_name`) 
- check if double quotes exist
- filter still existing blank `HGVSp_short`
- Query DB (first triage and after import, public DB)
```
select mutation_event me, mutation m, genetic_profile gp 
from mutation_event, mutation, genetic_profile
where me.mutation_event_id=m.mutation_event_id and m.genetic_profile_id=gp.genetic_profile_id 
and protein_change='mutated' 
and gp.stable_id LIKE "%prad_mskcc_cheny1_organoids_2014%"
```
- Compare mutated genes table in study view: public portal vs. triage portal

# QC comments:
### For `prad_mskcc_cheny1_organoids_2014` 
- [x] the `MUTATED` is still showing up in DB: try re-import to triage; if still not resolved, verify if this is the `DB using outdated mutation_event issue`
<img width="548" alt="Screen Shot 2020-04-28 at 8 01 51 PM" src="https://user-images.githubusercontent.com/5973438/80549478-5a7fb600-898b-11ea-809a-17a21c48a422.png">

- [x] columns seems to be shifted (see validation report https://4311-63335718-gh.circle-artifacts.com/0/~/test-reports/ERRORS/prad_mskcc_cheny1_organoids_2014-validation.html)
<img width="1084" alt="Screen Shot 2020-04-28 at 8 30 17 PM" src="https://user-images.githubusercontent.com/5973438/80550940-c2380000-898f-11ea-863f-d4348df2ddc7.png">

### For `sclc_ucologne_2015`
- [x] line 38647 is still have `HGVSp_short` as blank (didn't see this study logged in the spreadsheet as having issue caused by gnome nexus); also for this line, strand is `-` instead of `+`
- [x] line 38646: GN seems to give a different consequence `downstream` in canonical: see this URL: http://annotation.genomenexus.org/hgvs/3:g.147106648T%3EC?isoformOverrideSource=mskcc&cancerHotspots=summary
- [x] caused by the above, still have two `mutated` events in DB
- [x] one existing mutation went missing for RB1 (see screenshot, `mutated gene` table from public vs. triage portal)
<img width="364" alt="Screen Shot 2020-04-28 at 8 19 11 PM" src="https://user-images.githubusercontent.com/5973438/80550308-b5b2a800-898d-11ea-9ad9-743be07a6239.png">
<img width="405" alt="Screen Shot 2020-04-28 at 8 19 06 PM" src="https://user-images.githubusercontent.com/5973438/80550307-b4817b00-898d-11ea-862c-ba59025954b6.png">

 ### Both studies
- [x] add the mutated fix to MSK isoformed MAFs
- [x] remove " (double quote) signs
- [x] fix validation errors; make sure the PR Circle CI validation pass