### PR TITLE
gbm_columbia_2019: update based on ritika comments

### DIFF
--- a/public/gbm_columbia_2019/data_clinical_patient.txt
+++ b/public/gbm_columbia_2019/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2081f9b3242937ae13daa3af9865c45b8617663cc302411edf0e28c1c9928ba9
-size 11636
+oid sha256:28b6ec0b3070d50744dddd6751f03f19d256e9bb8b8af849e0b22208eee2fc4a
+size 11623


### PR DESCRIPTION
Quick fix of gbm_columbia_2019 based on Ritika's comments (after the PR is merged) here: https://github.com/cBioPortal/datahub/pull/1103