### PR TITLE
Quick fixes to lgg_tcga and crc_msk_2017

### DIFF
--- a/public/crc_msk_2017/data_clinical_sample.txt
+++ b/public/crc_msk_2017/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b46148a26ab1e1903221549128e164c67fcaae3a9fbdc08901b46461cce3b73
-size 265400
+oid sha256:b02d3899b6cdf06fe4dd3821f3f6913e8529abf5ff6f1c9ec08830a33819d4ce
+size 272621

--- a/public/crc_msk_2017/data_clinical_sample.txt
+++ b/public/crc_msk_2017/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b02d3899b6cdf06fe4dd3821f3f6913e8529abf5ff6f1c9ec08830a33819d4ce
-size 272621
+oid sha256:406d1c2c548130bf7d0b5ec44a12b04f7fd7ee83dc4644e3f56c353aafd2f7c5
+size 272588

--- a/public/lgg_tcga/data_mutsig.txt
+++ b/public/lgg_tcga/data_mutsig.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad083fb52ba8a96656ec8db5012d5ac63b6d0734c5326a76222fad8eef774c76
-size 2091055


### PR DESCRIPTION
lgg_tcga: removed mutsig file
crc_msk_2017: replace MSS with MSI Status in subtype assignment

# What?
Fix https://github.com/cBioPortal/datahub/issues/506
Fix https://github.com/cBioPortal/datahub/issues/570
