### PR TITLE
Adding new all sample z-score profile(Round-4)

### DIFF
--- a/public/all_phase2_target_2018_pub/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:070b72cfbd0c8ba16e87884aa6d6e905bed43faf29f2aa7d9a5dc28c1d1625b6
+size 39248582

--- a/public/all_phase2_target_2018_pub/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c069ca980ffd6ccc467edda32a7e85d9257ec815345e2693b474dab884a2ad9
+size 45758035

--- a/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: all_phase2_target_2018_pub
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_Zscores
-profile_name: mRNA Expression z-Scores (RNA Seq RPKM)
-profile_description: mRNA z-Scores (RNA Seq RPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA Expression z-Scores relative to diploid samples (RNA-Seq RPKM)
+profile_description: mRNA z-Scores (RNA-Seq RPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
 show_profile_in_analysis_tab: true
 data_filename: data_RNA_Seq_mRNA_median_Zscores.txt

--- a/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: aml_target_2018_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,4 +1,4 @@
-cancer_study_identifier: aml_target_2018_pub
+cancer_study_identifier: all_phase2_target_2018_pub
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores

--- a/public/all_phase2_target_2018_pub/meta_mRNA_median_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_mRNA_median_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: all_phase2_target_2018_pub
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_Zscores
-profile_name: mRNA Expression z-Scores (microarray)
+profile_name: mRNA Expression z-Scores relative to diploid samples (microarray)
 profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
 show_profile_in_analysis_tab: true
 data_filename: data_mRNA_median_Zscores.txt

--- a/public/all_phase2_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: aml_target_2018_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-scores relative to all samples (log microarray)
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/all_phase2_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
-profile_name: mRNA expression z-scores relative to all samples (log microarray)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-Scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/all_phase2_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/all_phase2_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,4 +1,4 @@
-cancer_study_identifier: aml_target_2018_pub
+cancer_study_identifier: all_phase2_target_2018_pub
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores

--- a/public/blca_tcga_pub_2017/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga_pub_2017/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06419b76854efafb3ca2730abb80f90bc31e65837768936a6bfdadb0df3fd47d
+size 61900551

--- a/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA z-Scores (RNA-Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA Expression z-Scores relative to diploid samples (RNA-Seq V2 RSEM)

--- a/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq V2 RSEM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq V2 RSEM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq V2 RSEM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq V2 RSEM)
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt

--- a/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: blca_tcga_pub_2017
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
+data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt

--- a/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/blca_tcga_pub_2017/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq V2 RSEM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RSEM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq V2 RSEM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq V2 RSEM)
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt

--- a/public/brca_metabric/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_metabric/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc09f2bdef1089d8266e3f1b4ac0c245a4daf1b389e359946193f19438d8bcc1
+size 344114686

--- a/public/brca_metabric/meta_mRNA_median_Zscores.txt
+++ b/public/brca_metabric/meta_mRNA_median_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_name: mRNA expression (microarray) z-scores relative to diploid samples
+profile_name: mRNA expression (microarray) z-Scores relative to diploid samples
 profile_description: mRNA z-Scores (Illumina Human v3 microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
 data_filename: data_mRNA_median_Zscores.txt

--- a/public/brca_metabric/meta_mRNA_median_Zscores.txt
+++ b/public/brca_metabric/meta_mRNA_median_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_name: mRNA expression (microarray) z-scores
-profile_description: Expression log intensity levels (Illumina Human v3 microarray) z-scores
+profile_name: mRNA expression (microarray) z-scores relative to diploid samples
+profile_description: mRNA z-Scores (Illumina Human v3 microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
 data_filename: data_mRNA_median_Zscores.txt

--- a/public/brca_metabric/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_metabric/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
-profile_name: mRNA expression z-scores relative to all samples (log Illumina Human v3 microarray)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (Illumina Human v3 microarray)
+profile_name: mRNA expression z-scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_metabric/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_metabric/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (Illumina Human v3 microarray)
-profile_name: mRNA expression z-scores relative to all samples (log microarray)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (Illumina Human v3 microarray)
+profile_name: mRNA expression z-Scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_metabric/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_metabric/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: brca_metabric
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-scores relative to all samples (log Illumina Human v3 microarray)
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_tcga_pub/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga_pub/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:348d4b2538d76f2c5a0b4f3d4e702e49680f6fae75f60b59650cb8bfb1410a6e
+size 69027239

--- a/public/brca_tcga_pub/meta_mRNA_median_Zscores.txt
+++ b/public/brca_tcga_pub/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 stable_id: mrna_median_Zscores
 profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
 show_profile_in_analysis_tab: true
-profile_name: mRNA Expression z-Scores (microarray)
+profile_name: mRNA Expression z-Scores relative to diploid samples (microarray)
 data_filename: data_mRNA_median_Zscores.txt

--- a/public/brca_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
-profile_name: mRNA expression z-scores relative to all samples (log microarray)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-Scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/brca_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/brca_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: brca_tcga_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-scores relative to all samples (log microarray)
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/cellline_ccle_broad/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/cellline_ccle_broad/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5211752175d44980cb00048c8ef1d6caa032cdb2777fbbd9bdb718d9c8cf831c
+size 116777582

--- a/public/cellline_ccle_broad/meta_mRNA_median_Zscores.txt
+++ b/public/cellline_ccle_broad/meta_mRNA_median_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (Affymetrix microarray)
-profile_name: mRNA Expression z-Scores (microarray)
+profile_description: mRNA z-Scores (Affymetrix microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA Expression z-Scores relative to diploid samples (microarray)
 data_filename: data_mRNA_median_Zscores.txt

--- a/public/cellline_ccle_broad/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/cellline_ccle_broad/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: cellline_ccle_broad
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Affymetrix microarray).
+profile_name: mRNA expression z-scores relative to all samples (log microarray)
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/cellline_ccle_broad/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/cellline_ccle_broad/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Affymetrix microarray).
-profile_name: mRNA expression z-scores relative to all samples (log microarray)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples  (Affymetrix microarray).
+profile_name: mRNA expression z-Scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/cll_broad_2015/data_RNA_Seq_expression_tpm_all_sample_Zscores.txt
+++ b/public/cll_broad_2015/data_RNA_Seq_expression_tpm_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18917515930d55cb933825e8ba90e251ccb1765fa43fd3eb445510bc4e49c8a3
+size 22928999

--- a/public/cll_broad_2015/meta_RNA_Seq_expression_tpm_all_sample_Zscores.txt
+++ b/public/cll_broad_2015/meta_RNA_Seq_expression_tpm_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_seq_tpm_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq TPM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq TPM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq TPM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq TPM)
 data_filename: data_RNA_Seq_expression_tpm_all_sample_Zscores.txt

--- a/public/cll_broad_2015/meta_RNA_Seq_expression_tpm_all_sample_Zscores.txt
+++ b/public/cll_broad_2015/meta_RNA_Seq_expression_tpm_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_seq_tpm_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq TPM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq TPM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq TPM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq TPM)
 data_filename: data_RNA_Seq_expression_tpm_all_sample_Zscores.txt

--- a/public/cll_broad_2015/meta_RNA_Seq_expression_tpm_all_sample_Zscores.txt
+++ b/public/cll_broad_2015/meta_RNA_Seq_expression_tpm_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: cll_broad_2015
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_seq_tpm_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq TPM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq TPM)
+data_filename: data_RNA_Seq_expression_tpm_all_sample_Zscores.txt

--- a/public/coadread_tcga_pub/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pub/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c86fd2b2bc6b2678d1d25a9195ce17f98958ded44e13f249acd489eb18fa981
+size 35713921

--- a/public/coadread_tcga_pub/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pub/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c107a001c4e526001536de2270c984e486cacdd260d5d777ef415bffa7158c0
+size 29143909

--- a/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_Zscores.txt
+++ b/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: coadread_tcga_pub
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_Zscores
-profile_description: mRNA z-Scores (RNA Seq RPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_description: mRNA z-Scores (RNA-Seq RPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
 show_profile_in_analysis_tab: true
-profile_name: mRNA Expression z-Scores (RNA Seq RPKM)
+profile_name: mRNA Expression z-Scores relative to diploid samples (RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_Zscores.txt

--- a/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: coadread_tcga_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga_pub/meta_mRNA_median_Zscores.txt
+++ b/public/coadread_tcga_pub/meta_mRNA_median_Zscores.txt
@@ -4,5 +4,5 @@ datatype: Z-SCORE
 stable_id: mrna_median_Zscores
 profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
 show_profile_in_analysis_tab: true
-profile_name: mRNA Expression z-Scores (microarray)
+profile_name: mRNA Expression z-Scores relative to diploid samples (microarray)
 data_filename: data_mRNA_median_Zscores.txt

--- a/public/coadread_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: coadread_tcga_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-scores relative to all samples (log microarray)
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/coadread_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/coadread_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
-profile_name: mRNA expression z-scores relative to all samples (log microarray)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-Scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_mayo_pdx_sarkaria_2019/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_mayo_pdx_sarkaria_2019/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e152a2ab7a45233f78a8a4c19d27430a37316512ef663aef18db9805da8d5398
+size 9612116

--- a/public/gbm_mayo_pdx_sarkaria_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_mayo_pdx_sarkaria_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_mayo_pdx_sarkaria_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_mayo_pdx_sarkaria_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_mayo_pdx_sarkaria_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_mayo_pdx_sarkaria_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: gbm_mayo_pdx_sarkaria_2019
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_tcga_pub/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga_pub/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12ac5f9cc47b66268798414388129efcad31698aebc0e84650b5aff5a6e426f4
+size 31242203

--- a/public/gbm_tcga_pub/meta_mRNA_median_Zscores.txt
+++ b/public/gbm_tcga_pub/meta_mRNA_median_Zscores.txt
@@ -1,6 +1,6 @@
 cancer_study_identifier: gbm_tcga_pub
 stable_id: mrna_median_Zscores
-profile_name: mRNA Expression z-Scores (microarray)
+profile_name: mRNA Expression z-Scores relative to diploid samples (microarray)
 profile_description: 18,698 genes in 503 GBM cases using median expression values from the Affymetrix U133, Affymetrix Exon, and Agilent Platforms. z-Scores are computed relative to the expression distribution of each gene in tumors that are diploid for this gene.
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE

--- a/public/gbm_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
-profile_name: mRNA expression z-scores relative to all samples (log microarray)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-Scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/gbm_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/gbm_tcga_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: gbm_tcga_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-scores relative to all samples (log microarray)
+data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga_pub/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pub/data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:841f500ec7c2697ad5dcc1117695d1ae2a6d37a4c62109a7345a1089fa7654b1
+size 10013844

--- a/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
+++ b/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_description: mRNA z-Scores (RNA Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
-profile_name: mRNA Expression z-Scores (RNA Seq V2 RSEM)
+profile_description: mRNA z-Scores (RNA-Seq V2 RSEM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA Expression z-Scores relative to diploid samples (RNA-Seq V2 RSEM)
 data_filename: data_RNA_Seq_v2_mRNA_median_Zscores.txt

--- a/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq V2 RESM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RESM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq V2 RESM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq V2 RESM)
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq V2 RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RPKM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq V2 RESM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RESM)
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq V2 RESM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq V2 RESM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq V2 RESM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq V2 RESM)
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
+++ b/public/kich_tcga_pub/meta_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: kich_tcga_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_v2_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq V2 RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq V2 RPKM)
+data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_Zscores.txt

--- a/public/mel_ucla_2016/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/mel_ucla_2016/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35d9831b6f3d314ff3fc5b45bb5349a846d6463664d3c8fa911b9569dad1660a
+size 4484365

--- a/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_name: mRNA expression z-scores (RNA-Seq)
-profile_description: Expression levels z-scores (RNA-Seq FPKM)
+profile_name: mRNA expression z-scores relative to diploid samples (RNA-Seq FPKM)
+profile_description: mRNA z-Scores (RNA Seq FPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
 data_filename: data_RNA_Seq_mRNA_median_Zscores.txt

--- a/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_name: mRNA expression z-scores relative to diploid samples (RNA-Seq FPKM)
+profile_name: mRNA expression z-Scores relative to diploid samples (RNA-Seq FPKM)
 profile_description: mRNA z-Scores (RNA Seq FPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
 data_filename: data_RNA_Seq_mRNA_median_Zscores.txt

--- a/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: mel_ucla_2016
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq FPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq FPKM)
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq FPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq FPKM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq FPKM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq FPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq FPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq FPKM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq FPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq FPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/utuc_cornell_baylor_mdacc_2019/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/utuc_cornell_baylor_mdacc_2019/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f52e60593911c97449375386ad0a08229a1ef59a147d180474570b661b8d26ee
+size 4585582

--- a/public/utuc_cornell_baylor_mdacc_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/utuc_cornell_baylor_mdacc_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/utuc_cornell_baylor_mdacc_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/utuc_cornell_baylor_mdacc_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/utuc_cornell_baylor_mdacc_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/utuc_cornell_baylor_mdacc_2019/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: utuc_cornell_baylor_mdacc_2019 
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/wt_target_2018_pub/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/wt_target_2018_pub/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a2be94a9c1c9d9c1407d9ab926d7369a0d6b91e31874729f3f3419576aab059
+size 22704032

--- a/public/wt_target_2018_pub/data_mRNA_median_all_sample_Zscores.txt
+++ b/public/wt_target_2018_pub/data_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92a82633937ccacfa421dae08e32c9fd87c1082b525276cc9f426c04a5fbf774
+size 19522551

--- a/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_Zscores.txt
+++ b/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: wt_target_2018_pub
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_Zscores
-profile_name: mRNA Expression z-Scores (RNA Seq RPKM)
-profile_description: mRNA z-Scores (RNA Seq RPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA Expression z-Scores relative to diploid samples (RNA-Seq RPKM)
+profile_description: mRNA z-Scores (RNA-Seq RPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
 show_profile_in_analysis_tab: true
 data_filename: data_RNA_Seq_mRNA_median_Zscores.txt

--- a/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: wt_target_2018_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: rna_seq_mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA Seq RPKM)
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/wt_target_2018_pub/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples (RNA-Seq RPKM).
-profile_name: mRNA expression z-scores relative to all samples (log RNA-Seq RPKM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq RPKM).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq RPKM)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt

--- a/public/wt_target_2018_pub/meta_mRNA_median_Zscores.txt
+++ b/public/wt_target_2018_pub/meta_mRNA_median_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: wt_target_2018_pub
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_Zscores
-profile_name: mRNA Expression z-Scores (microarray)
+profile_name: mRNA Expression z-Scores relative to diploid samples (microarray)
 profile_description: mRNA z-Scores (Agilent microarray) compared to the expression distribution of each gene tumors that are diploid for this gene.
 show_profile_in_analysis_tab: true
 data_filename: data_mRNA_median_Zscores.txt

--- a/public/wt_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/wt_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
-profile_name: mRNA expression z-scores relative to all samples (log microarray)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-Scores relative to all samples (log microarray)
 data_filename: data_mRNA_median_all_sample_Zscores.txt

--- a/public/wt_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
+++ b/public/wt_target_2018_pub/meta_mRNA_median_all_sample_Zscores.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: wt_target_2018_pub
+genetic_alteration_type: MRNA_EXPRESSION
+datatype: Z-SCORE
+stable_id: mrna_median_all_sample_Zscores
+show_profile_in_analysis_tab: true
+profile_description: Log-transformed mRNA z-scores compared to the expression distribution of all samples  (Agilent microarray).
+profile_name: mRNA expression z-scores relative to all samples (log microarray)
+data_filename: data_mRNA_median_all_sample_Zscores.txt


### PR DESCRIPTION
Adding new all sample zscore profile for the following studies:

1. kich_tcga_pub
2. gbm_tcga_pub
3. gbm_mayo_pdx_sarkaria_2019
4. coadread_tcga_pub
5. cll_broad_2015
6. celline_ccle_broad
7. brca_tcga_pub
8. brca_metabric
9. all_phase2_target_2018_pub
10. utuc_cornell_baylor_mdacc_2019
11. wt_target_2018_pub
12. blac_tcga_pub_2017
13. mel_ucla_2016.

Cancer studies updated in this pull request:
- a
- .

# checks
For all pull requests:
- [x] Passes validation
