### PR TITLE
set show_profile_in_analysis_tab to TRUE for expression profile

### DIFF
--- a/public/nepc_wcm_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
+++ b/public/nepc_wcm_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: nepc_wcm_2016
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_Zscores
-show_profile_in_analysis_tab: false
+show_profile_in_analysis_tab: true
 profile_name: mRNA expression z-Scores relative to diploid samples
 profile_description: mRNA expression z-Scores compared to the expression distribution of each gene tumors that are diploid for this gene.
 data_filename: data_RNA_Seq_mRNA_median_Zscores.txt


### PR DESCRIPTION
Cancer studies updated in this pull request:
- nepc_wcm_2016

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

