### PR TITLE
nsclc_tracerx_2017: more mutated fix

### DIFF
--- a/public/nsclc_tracerx_2017/data_mutations_extended.txt
+++ b/public/nsclc_tracerx_2017/data_mutations_extended.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81cc075e88df255f34ebd5fb82d78bdbc4f851efde3a7a743fc7d19e89ef5877
-size 82098635
+oid sha256:24b4e739ee2e78edb98359f22bdb147e6f5c79b0a6422b501652caedca954e54
+size 82098522

--- a/public/nsclc_tracerx_2017/data_mutations_mskcc.txt
+++ b/public/nsclc_tracerx_2017/data_mutations_mskcc.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:421feb821100ffea37fc29e8fcc5099af5df0995d3f6b298faab88bd047f0fc1
-size 82098633
+oid sha256:c2e667c645c39c0b0d8016d714a5483e66c5c551a978b35b386ba75185a2add9
+size 82098520


### PR DESCRIPTION
- update variant classification intergenic to IGR
- fix incorrect annotations from annotator (targeted region -> IGR) after manual checking

