### PR TITLE
blca_tcga_pub_2017: removed columns with no values

### DIFF
--- a/public/blca_tcga_pub_2017/data_clinical_patient.txt
+++ b/public/blca_tcga_pub_2017/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:376ffe502442968769a32aaffbf1399e1339c640e3a56d3c2b9e76cf8392ef28
-size 399832
+oid sha256:7fa8fbf9286eacbef67ee4841bf930bf248628138c1cc69dd810c3bf7b47f942
+size 363378

--- a/public/blca_tcga_pub_2017/data_clinical_sample.txt
+++ b/public/blca_tcga_pub_2017/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1f3787993546cc65ed49d981e508ac23bfc09e8f8a62a05dd88e7a15fe0c19e
-size 165144
+oid sha256:dcb00c71a8576ac7c976bb614ff9c6d39e63b9a12b67950c5b6b3fbf88be49e1
+size 97954


### PR DESCRIPTION
# What?
Fix #1154 

Cancer studies updated in this pull request:
- blca_tcga_pub_2017
