### PR TITLE
renamed 'Relative linear copy-number values'

### DIFF
--- a/public/acc_tcga/meta_linear_CNA.txt
+++ b/public/acc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/blca_tcga/meta_linear_CNA.txt
+++ b/public/blca_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/blca_tcga_pub/meta_linear_CNA.txt
+++ b/public/blca_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/blca_tcga_pub_2017/meta_linear_CNA.txt
+++ b/public/blca_tcga_pub_2017/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/brca_tcga/meta_linear_CNA.txt
+++ b/public/brca_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/brca_tcga_pub/meta_linear_CNA.txt
+++ b/public/brca_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/brca_tcga_pub2015/meta_linear_CNA.txt
+++ b/public/brca_tcga_pub2015/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/cesc_tcga/meta_linear_CNA.txt
+++ b/public/cesc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/chol_tcga/meta_linear_CNA.txt
+++ b/public/chol_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/coadread_tcga/meta_linear_CNA.txt
+++ b/public/coadread_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/coadread_tcga_pub/meta_linear_CNA.txt
+++ b/public/coadread_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/dlbc_tcga/meta_linear_CNA.txt
+++ b/public/dlbc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/esca_tcga/meta_linear_CNA.txt
+++ b/public/esca_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/gbm_tcga/meta_linear_CNA.txt
+++ b/public/gbm_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/gbm_tcga_pub2013/meta_linear_CNA.txt
+++ b/public/gbm_tcga_pub2013/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/hnsc_tcga/meta_linear_CNA.txt
+++ b/public/hnsc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/hnsc_tcga_pub/meta_linear_CNA.txt
+++ b/public/hnsc_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/kich_tcga/meta_linear_CNA.txt
+++ b/public/kich_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/kich_tcga_pub/meta_linear_CNA.txt
+++ b/public/kich_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/kirc_tcga/meta_linear_CNA.txt
+++ b/public/kirc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/kirc_tcga_pub/meta_linear_CNA.txt
+++ b/public/kirc_tcga_pub/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 stable_id: linear_CNA
 data_filename: data_linear_CNA.txt
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number valuesdata_filename: data_linear_CNA.txt
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/kirp_tcga/meta_linear_CNA.txt
+++ b/public/kirp_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/laml_tcga/meta_linear_CNA.txt
+++ b/public/laml_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/laml_tcga_pub/meta_linear_CNA.txt
+++ b/public/laml_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/lgg_tcga/meta_linear_CNA.txt
+++ b/public/lgg_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/lihc_tcga/meta_linear_CNA.txt
+++ b/public/lihc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/luad_tcga/meta_linear_CNA.txt
+++ b/public/luad_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/luad_tcga_pub/meta_linear_CNA.txt
+++ b/public/luad_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/lusc_tcga/meta_linear_CNA.txt
+++ b/public/lusc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/lusc_tcga_pub/meta_linear_CNA.txt
+++ b/public/lusc_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/meso_tcga/meta_linear_CNA.txt
+++ b/public/meso_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/ov_tcga/meta_linear_CNA.txt
+++ b/public/ov_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/ov_tcga_pub/meta_linear_CNA.txt
+++ b/public/ov_tcga_pub/meta_linear_CNA.txt
@@ -1,7 +1,7 @@
 cancer_study_identifier: ov_tcga_pub
 stable_id: linear_CNA
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 show_profile_in_analysis_tab: false

--- a/public/paad_tcga/meta_linear_CNA.txt
+++ b/public/paad_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/pcpg_tcga/meta_linear_CNA.txt
+++ b/public/pcpg_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/prad_tcga/meta_linear_CNA.txt
+++ b/public/prad_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/prad_tcga_pub/meta_linear_CNA.txt
+++ b/public/prad_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/sarc_tcga/meta_linear_CNA.txt
+++ b/public/sarc_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/skcm_tcga/meta_linear_CNA.txt
+++ b/public/skcm_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/stad_tcga/meta_linear_CNA.txt
+++ b/public/stad_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/stad_tcga_pub/meta_linear_CNA.txt
+++ b/public/stad_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/tgct_tcga/meta_linear_CNA.txt
+++ b/public/tgct_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/thca_tcga_pub/meta_linear_CNA.txt
+++ b/public/thca_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/thym_tcga/meta_linear_CNA.txt
+++ b/public/thym_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/ucec_tcga/meta_linear_CNA.txt
+++ b/public/ucec_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/ucec_tcga_pub/meta_linear_CNA.txt
+++ b/public/ucec_tcga_pub/meta_linear_CNA.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: COPY_NUMBER_ALTERATION
 datatype: CONTINUOUS
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values
 data_filename: data_linear_CNA.txt

--- a/public/ucs_tcga/meta_linear_CNA.txt
+++ b/public/ucs_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values

--- a/public/uvm_tcga/meta_linear_CNA.txt
+++ b/public/uvm_tcga/meta_linear_CNA.txt
@@ -4,5 +4,5 @@ datatype: CONTINUOUS
 data_filename: data_linear_CNA.txt
 stable_id: linear_CNA
 show_profile_in_analysis_tab: false
-profile_description: Relative linear copy-number values for each gene (from Affymetrix SNP6).
-profile_name: Relative linear copy-number values
+profile_description: Capped relative linear copy-number values for each gene (from Affymetrix SNP6).
+profile_name: Capped relative linear copy-number values


### PR DESCRIPTION
# What?
Fix #246  
- Renamed the linear_CNA profile name and descriptions from `Relative linear copy-number values` to `Capped relative linear copy-number values`

Cancer studies updated in this pull request:
- All TCGA studies with linear_CNA profile