### PR TITLE
Updated the clinical attribute gender to sex

### DIFF
--- a/public/coad_cptac_2019/data_clinical_patient.txt
+++ b/public/coad_cptac_2019/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:441f8a00c7f8de31bf82a9365584f0377b71ad774c01fe42e3b065fdcc722c11
-size 14561
+oid sha256:43f409efb76f623b51e97f9327b94f219f0cc5033adbe4d43235a26f8b8870bd
+size 14621

--- a/public/coad_cptac_2019/data_clinical_sample.txt
+++ b/public/coad_cptac_2019/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1502b94db9ca75b6822eec949c0e79a3dd4405a1ddec2bee8de4afbd3fefbc7
-size 11042
+oid sha256:b75ec4b9662b493540e158fd8fa85dd8778d0ee33cb957ec56ae09d30ba09238
+size 11064


### PR DESCRIPTION
#131 

Cancer studies updated in this pull request:
1. coad_cptac_2019

# checks

1. SEX / GENDER: The sex attribute values have been normalized to Male, Female across all studies.
- [x] coad_cptac_2019: replace Gender to Sex.
- [ ]  Check if Sex was added to women's cancer (breast, ovarian, breast, anything else) and men's cancer (prostate, testicular, and penile).
