### PR TITLE
Issue #5: fix data issues reported by validator

### DIFF
--- a/public/blca_tcga_pub_2017/data_clinical_patient.txt
+++ b/public/blca_tcga_pub_2017/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fa8fbf9286eacbef67ee4841bf930bf248628138c1cc69dd810c3bf7b47f942
-size 363378
+oid sha256:471dfb27ef3c1bde1f588df65ffaf1b104cebd7e610705f1e2752f1e5f8dc801
+size 363382

--- a/public/brca_tcga/data_bcr_clinical_data_patient.txt
+++ b/public/brca_tcga/data_bcr_clinical_data_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e529a34a01ebeb91d948a64f04fc2f0988b68a57054316f8ca89c21e1a6bff46
-size 1703850
+oid sha256:7dc9cad4078fcf4244c36f51639e55d8e2b9bc5fbd97ad5b91864e58a9903cfb
+size 1703852

--- a/public/luad_tcga/data_bcr_clinical_data_patient.txt
+++ b/public/luad_tcga/data_bcr_clinical_data_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92f83bbfdb49d0e9707799cc132911b1bc7b48b017cbd5f1af0a6b78fe027728
-size 489859
+oid sha256:020ec1cbb9186d08d8764538402605c6ac3368c8e4b659416a07c23a84d667e8
+size 489861

--- a/public/stad_tcga/data_RNA_Seq_expression_median.txt
+++ b/public/stad_tcga/data_RNA_Seq_expression_median.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:577f7ffec9c9bb3f9a1413d488e4106f576de99384de0e90a8e2ea3642e2170b
-size 6090936
+oid sha256:4e7924086ce3509eacc907b886369bc96f8a7fc9b918f18d6dcd85fde44114c5
+size 6090456

--- a/public/stad_tcga/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/stad_tcga/data_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b63d530c120dc984d805c09fb81c9b686d3f5465328d087babef4fd92081594
-size 6157944
+oid sha256:2eadef3ecd075140608afcea6f333413227f0be1d31a7b813243315ca7cd398d
+size 6157465


### PR DESCRIPTION
# What?
Fix #5  .

Cancer studies updated in this pull request:
- updated the data type of clinical attributes in blca_tcga_pub_2017, brca_tcga, luad_tcga (changed DAYS_TO_DEATH, INITIAL_PATHOLOGIC_DX_YEAR, KARNOFSKY_PERFORMANCE_SCORE from STRING to NUMBER)
- data_RNA_Seq_expression_median.txt in study STAD has 68 rows where Entrez gene identifier has non-numeric values such as AC2, HP08777, MIG7. Removed the gene synonyms from Entrez column.