### PR TITLE
fix unknown/ambiguous symbols in the gbm_tcga_pub, novartis_broad and ucla gene panels

### DIFF
--- a/reference_data/gene_panels/data_gene_panel_gbm_tcga_pub.txt
+++ b/reference_data/gene_panels/data_gene_panel_gbm_tcga_pub.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8445d4eb45a7f657560cc09876a29ffd38ec099558439d7b7bdc887f4a37a8b
-size 3666
+oid sha256:e316572c82ca313159cce7810204e2419b8f1b694bcc00f7180fe0b16055f42e
+size 3207

--- a/reference_data/gene_panels/data_gene_panel_novartis_broad_1651.txt
+++ b/reference_data/gene_panels/data_gene_panel_novartis_broad_1651.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9beeda400d677d5907116d2ace04a708e19748100f6d372f086db0ebcdae63db
-size 25766
+oid sha256:2adb8a6c0bda40ce21ede37b9d6d4990e7f873951a5e31ebf9979ac2d8f7df6d
+size 22989

--- a/reference_data/gene_panels/data_gene_panel_ucla_1202.txt
+++ b/reference_data/gene_panels/data_gene_panel_ucla_1202.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:669db1562a4f799af224a62d5b70d133243e0269d012f7dbed395c0fee4b0265
-size 7690
+oid sha256:424e93f1af12e9452490d3baefae9a5f71d3e9f9482ba9d518c2f1ce4c1502fb
+size 6981


### PR DESCRIPTION
# What?
The reimport of the 3 panels to database failed with the issue that couple of genes in the panels are not known to our gene table or are ambiguous (same symbol mapping to multiple entrez ids). Most of these unknown genes were withdrawn or replaced to new IDs in NCBI. 
Tried reimporting only the below 3 panels (there might be other panels with the same issue). 

Panels updated in this pull request:
- NOVARTIS_BROAD_1651
- UCLA_1202
- gbm_tcga_pub_cancer_panel

Updated made:
1. UCLA panel: The following symbols were replaced in NCBI to

> C10ORF118	 - 55088	CCDC186
> C11ORF48	- 102288414	C11ORF98
> C12ORF12	- 196477	CCER1
> C14ORF43	- 91748	ELMSAN1
> C17ORF57	- 124989	EFCAB13
> C18ORF34	- 374864	CCDC178
> C1ORF65	- 164127	CCDC185
> C22ORF25	- 128989	TANGO2
> C2ORF55	- 343990	KIAA1211L
> C5ORF44	- 80006	TRAPPC13
> C8ORF45	- 157777	MCMDC2
> C9ORF103	- 414328	IDNK

> DKK2.00	27123
> PTCH - removed the gene symbol from panel since it is alias to PTCH1 and both the gene and alias are present in the panel with same entrez id.
> BPIL2 - removed the gene symbol from panel since it is alias to BPIFC and both the gene and alias are present in the panel with same entrez id.

2. Novartis panel genes mapped to:
> The following symbols are part of ONCOTATOR_GENE_SYMBOL column in the maf.
> LOC146336	- 146336
> LOC100130776	- 100130776
> LOC90586	- 90586
> FLJ45340	- 100130600
> LOC220429	- 220429
> LOC375190	- 375190
> LOC649330	- 343069
> LOC100130386	- 100130386
> LOC339674	- 339674
> LOC642587	- 642587
> LOC200030	- 100288142
> LOC152217	- 152217
> MGC42105	- 167359
> LOC283392	- 283392
> LOC390595	- 390595
> LOC100133957	- 100133957
> LOC134466	- 134466

> C14ORF184 - removed from panel since the entry is withdrawn from NCBI and the associated entrez_id is not in portal gene table.
> UNKNOWN - removed from panel. Not a valid symbol
> LOC401093 - removed from panel. Gene not seen in MAF and unsure of the location 
> LOC389791 - removed from panel. Gene not seen in MAF and unsure of the location 
> LOC100130557 - removed from panel. Gene not seen in MAF and unsure of the location
> 

3. gbm panel :

> RP6-213H19.1 - removed from the panel. Gene not seen in MAF and unsure of the location