### PR TITLE
Correct Sample Association

### DIFF
--- a/public/lgg_ucsf_2014/data_timeline_specimen.txt
+++ b/public/lgg_ucsf_2014/data_timeline_specimen.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e48ee8b3827f34f410fc7bccfa55558ff76350faaa16ef3b361ff4353b270b6
-size 2672
+oid sha256:de007204dc4cf13e9d01c1aea0cc769df32b7f917c023e029346db9afd1612af
+size 2673


### PR DESCRIPTION
# What?
In the data_timeline_specimen.txt, sample P26_Pri_B was incorrectly
associated with sample P24, contradicting the association made
in data_clinical_sample.txt. This change switches P26_Pri_B to
being associated with P26, as it is in data_clinical_sample.txt

Cancer studies updated in this pull request:
- lgg_ucsf_2014

# checks
For all pull requests:
- [x] Passes validation
