### PR TITLE
brca_jup_msk_2020: added study

### DIFF
--- a/public/brca_jup_msk_2020/case_lists/cases_all.txt
+++ b/public/brca_jup_msk_2020/case_lists/cases_all.txt
@@ -1,0 +1,6 @@
+cancer_study_identifier: brca_jup_msk_2020
+stable_id: brca_jup_msk_2020_all
+case_list_name: All samples
+case_list_description: All samples (5 samples)
+case_list_category: all_cases_in_study
+case_list_ids: JuP3-JP	JuP3-IDC	JuP2	JuP1	JuP3-DCIS

--- a/public/brca_jup_msk_2020/case_lists/cases_sequenced.txt
+++ b/public/brca_jup_msk_2020/case_lists/cases_sequenced.txt
@@ -1,0 +1,6 @@
+cancer_study_identifier: brca_jup_msk_2020
+stable_id: brca_jup_msk_2020_sequenced
+case_list_name: Samples with mutation data
+case_list_description: Samples with mutation data (5 samples)
+case_list_category: all_cases_with_mutation_data
+case_list_ids: JuP3-JP	JuP3-IDC	JuP2	JuP1	JuP3-DCIS

--- a/public/brca_jup_msk_2020/data_clinical_sample.txt
+++ b/public/brca_jup_msk_2020/data_clinical_sample.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5920b66ab5f2947162ff5aee05dc981236b395caefc79f3279e58cc28f33e72
+size 722

--- a/public/brca_jup_msk_2020/data_cna_hg19.seg
+++ b/public/brca_jup_msk_2020/data_cna_hg19.seg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a21bdcbac225dd92e6e1c2986e1c87bf83c75ba4e63b7ea2076657b7b82a5c6
+size 10095

--- a/public/brca_jup_msk_2020/data_mutations_extended.txt
+++ b/public/brca_jup_msk_2020/data_mutations_extended.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0427870c4ed2685daec0fbb369c9e351948cca6537c84f7eedeb7368f5092c8
+size 23300

--- a/public/brca_jup_msk_2020/data_mutations_mskcc.txt
+++ b/public/brca_jup_msk_2020/data_mutations_mskcc.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6771b52f968b5f42338a9f69050dfc49e418650d0a29f8bc7ec239e4c2dd4709
+size 23686

--- a/public/brca_jup_msk_2020/meta_clinical_sample.txt
+++ b/public/brca_jup_msk_2020/meta_clinical_sample.txt
@@ -1,0 +1,1 @@
+cancer_study_identifier: brca_jup_msk_2020genetic_alteration_type: CLINICALdatatype: SAMPLE_ATTRIBUTESdata_filename: data_clinical_sample.txt

--- a/public/brca_jup_msk_2020/meta_cna_hg19_seg.txt
+++ b/public/brca_jup_msk_2020/meta_cna_hg19_seg.txt
@@ -1,0 +1,1 @@
+cancer_study_identifier: brca_jup_msk_2020genetic_alteration_type: COPY_NUMBER_ALTERATION	datatype: SEG	reference_genome_id: hg19	description: Somatic CNA data	data_filename: data_cna_hg19.seg

--- a/public/brca_jup_msk_2020/meta_mutations_extended.txt
+++ b/public/brca_jup_msk_2020/meta_mutations_extended.txt
@@ -1,0 +1,1 @@
+cancer_study_identifier: brca_jup_msk_2020genetic_alteration_type: MUTATION_EXTENDEDdatatype: MAFstable_id: mutationsshow_profile_in_analysis_tab: TRUEprofile_description: Mutation data from Whole Exome Sequencingprofile_name: Mutationsdata_filename: data_mutations_extended.txt

--- a/public/brca_jup_msk_2020/meta_study.txt
+++ b/public/brca_jup_msk_2020/meta_study.txt
@@ -1,0 +1,1 @@
+type_of_cancer:	brcacancer_study_identifier: brca_jup_msk_2020name: Juvenile Papillomatosis and Breast Cancer (MSK, 2020)short_name: Juvenile papillomatosis (MSK, 2020)description: Whole-exome sequencing analysis of juvenile papillomatosis and coexisting breast carcinoma.groups: PUBLIC


### PR DESCRIPTION
Cancer studies updated in this pull request:
- brca_jup_msk_2020

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

