### PR TITLE
nbl_target_2018_pub: fix stable_id and datatype

### DIFF
--- a/public/nbl_target_2018_pub/meta_expression_median.txt
+++ b/public/nbl_target_2018_pub/meta_expression_median.txt
@@ -1,8 +1,8 @@
 cancer_study_identifier: nbl_target_2018_pub
-stable_id: mirna_median_Zscores
+stable_id: mrna
 profile_name: mRNA expression (microarray)
 profile_description: mRNA expression levels (Affymetrix microarray)
 genetic_alteration_type: MRNA_EXPRESSION
-datatype: Z-SCORE
+datatype: CONTINUOUS
 show_profile_in_analysis_tab: false
 data_filename:data_expression_median.txt


### PR DESCRIPTION
# What?
Fix #794  .

Cancer studies updated in this pull request:
- nbl_target_2018_pub: The stable_id of data_expression_median profile was mislabelled as miRNA zscores https://raw.githubusercontent.com/cBioPortal/datahub/master/public/nbl_target_2018_pub/meta_expression_median.txt. 
Cross checked the source and it is affymetrix gene expression data. 