### PR TITLE
all_phase2_target_2018_pub: update methylation profile description

### DIFF
--- a/public/all_phase2_target_2018_pub/meta_methylation_hm27.txt
+++ b/public/all_phase2_target_2018_pub/meta_methylation_hm27.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: all_phase2_target_2018_pub
 genetic_alteration_type: METHYLATION
 datatype: CONTINUOUS
 stable_id: methylation_hm27
-profile_description: Methylation beta-values (hm27 assay). For genes with multiple methylation probes, the probe least correlated with expression is selected.
+profile_description: Median normalized log2-transformed HpaII/MspI ratios from HELP assay on Nimblegen microarray platform. For genes with multiple methylation probes, the probe least correlated with expression is selected.
 show_profile_in_analysis_tab: false
-profile_name: Methylation (hm27)
+profile_name: Methylation (HELP Assay)
 data_filename:data_methylation_hm27.txt


### PR DESCRIPTION
# What?
Fix #788  

**Issue:**
The profile description says beta-values. Cross checking the source https://ocg.cancer.gov/programs/target/target-methods#441 and https://target-data.nci.nih.gov/Public/ALL/methylation_array/Phase2/ L2 or L3 shows the values are `median normalized log2-transformed HpaII/MspI ratios from HELP assay on Nimblegen microarray platform.`