### PR TITLE
mel_ucla_2016: Update RNA-Seq profile name and description

### DIFF
--- a/public/mel_ucla_2016/meta_RNA_Seq_expression_median.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_expression_median.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: CONTINUOUS
 stable_id: rna_seq_mrna
 show_profile_in_analysis_tab: false
-profile_name: mRNA expression (RNA Seq)
-profile_description: Expression levels (RNA-Seq FPKM)
+profile_name: mRNA expression (RNA Seq read counts)
+profile_description: Expression levels (RNA Seq read counts)
 data_filename: data_RNA_Seq_expression_median.txt

--- a/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_Zscores
 show_profile_in_analysis_tab: true
-profile_name: mRNA expression z-scores (RNA Seq)
-profile_description: mRNA z-Scores (RNA Seq FPKM) compared to the expression distribution of each gene tumors that are diploid for this gene.
+profile_name: mRNA expression z-scores (RNA Seq read counts)
+profile_description: mRNA z-Scores (RNA Seq read counts) compared to the expression distribution of each gene tumors that are diploid for this gene.
 data_filename: data_RNA_Seq_mRNA_median_Zscores.txt

--- a/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
+++ b/public/mel_ucla_2016/meta_RNA_Seq_mRNA_median_all_sample_Zscores.txt
@@ -3,6 +3,6 @@ genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_mrna_median_all_sample_Zscores
 show_profile_in_analysis_tab: true
-profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA-Seq FPKM).
-profile_name: mRNA expression z-Scores relative to all samples (log RNA-Seq FPKM)
+profile_description: Log-transformed mRNA z-Scores compared to the expression distribution of all samples (RNA Seq read counts).
+profile_name: mRNA expression z-Scores relative to all samples (log RNA Seq read counts)
 data_filename: data_RNA_Seq_mRNA_median_all_sample_Zscores.txt


### PR DESCRIPTION
# What?
Fix #1304 .

Changes made:
- The description of the RNA-Seq profile says it was FPKM but the data is read counts.
- Updated the profile name and description accordingly. 
