### PR TITLE
Set zscores relative to normal samples profile to be shown on query page

### DIFF
--- a/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/blca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: blca_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/brca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: brca_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/chol_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: chol_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: coadread_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/esca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: esca_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/hnsc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: hnsc_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/kich_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: kich_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/kirc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: kirc_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/kirp_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: kirp_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/lihc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: lihc_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/luad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: luad_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/lusc_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: lusc_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/prad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: prad_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/stad_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: stad_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/thca_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: thca_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt

--- a/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
+++ b/public/ucec_tcga_pan_can_atlas_2018/meta_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt
@@ -2,7 +2,7 @@ cancer_study_identifier: ucec_tcga_pan_can_atlas_2018
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: Z-SCORE
 stable_id: rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores
-show_profile_in_analysis_tab: FALSE
+show_profile_in_analysis_tab: TRUE
 profile_name: mRNA expression z-scores relative to normal samples (log RNA Seq V2 RSEM)
 profile_description: Expression z-scores of tumor samples compared to the expression distribution of all log-transformed mRNA expression of adjacent normal samples in the cohort.
 data_filename: data_RNA_Seq_v2_mRNA_median_all_sample_ref_normal_Zscores.txt


### PR DESCRIPTION
# What?
Fix #1348 
Updated the `show_profile_in_analysis_tab` to TRUE instead of FALSE in `rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores` profile.