### PR TITLE
Add missing survival months/status

### DIFF
--- a/public/brca_tcga_pan_can_atlas_2018/data_clinical_patient.txt
+++ b/public/brca_tcga_pan_can_atlas_2018/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ef285b67ae10efd8ea4158078b1f6a3b3a974beaf8b7246bf959d7077d8def3
-size 368160
+oid sha256:940c062dd2357f2318a8b89b30c073a21de52cbc6e9142c75a6f6218172a67ea
+size 368191

--- a/public/gbm_tcga/data_bcr_clinical_data_patient.txt
+++ b/public/gbm_tcga/data_bcr_clinical_data_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dea2c3fd56c3d56a379f8d6c5f33477148bc1c6bf76a2149977a810b397a1029
-size 278519
+oid sha256:9790667d31fbe6b9e09c8a4d375309360260a88b055f2cf6dbaf9cf28895e556
+size 278508

--- a/public/lgg_tcga/data_bcr_clinical_data_patient.txt
+++ b/public/lgg_tcga/data_bcr_clinical_data_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c23a3bc83335dc308f8da60be100795b6ebdb433ea3d5058367c99fcf4ba5464
-size 353460
+oid sha256:bf2e45656b8c0ffb846a53acc74beeb7dfef0dc84e27ba19c71161642b23bde0
+size 353450

--- a/public/lgg_tcga_pan_can_atlas_2018/data_clinical_patient.txt
+++ b/public/lgg_tcga_pan_can_atlas_2018/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6806df9619874612b322c8a491a0b26b0dfbc1bc805397020cad1a751fdb593
-size 167084
+oid sha256:a85250dea2b969cd17ad1b6d4779604274bc8a58912fa53d3f1083c5f542c141
+size 167096


### PR DESCRIPTION
# What?
Fix #130 .

Cancer studies updated in this pull request:
- brca_tcga_pan_can_atlas_2018
- gbm_tcga
- lgg_tcga
- lgg_tcga_pan_can_atlas_2018

Studies looked into:
brca_tcga_pan_can_atlas_2018
coadread_tcga_pan_can_atlas_2018
gbm_tcga
hnsc_tcga_pan_can_atlas_2018
kich_tcga
kirp_tcga
kirp_tcga_pan_can_atlas_2018
lgg_tcga
lgg_tcga_pan_can_atlas_2018
lihc_tcga
lihc_tcga_pan_can_atlas_2018
meso_tcga_pan_can_atlas_2018
thym_tcga
thym_tcga_pan_can_atlas_2018
ucec_tcga
ucec_tcga_pan_can_atlas_2018