### PR TITLE
swap dates for TMZ vs XRT for P04

### DIFF
--- a/public/lgg_ucsf_2014/data_timeline_treatment.txt
+++ b/public/lgg_ucsf_2014/data_timeline_treatment.txt
@@ -1,3 +1,21 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2168838a9b0700772e95cfbbb33fb00c4a26cf3f02395130438b10c0eab3029
-size 1114
+PATIENT_ID	START_DATE	STOP_DATE	EVENT_TYPE	TREATMENT_TYPE	SUBTYPE	AGENT
+P01	611	977	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P01	977	1007	TREATMENT	Medical Therapy		TMZ + accutane
+P01	1007	1038	TREATMENT	Medical Therapy		TMZ + thalidomide
+P01	1088	1132	TREATMENT	Radiation Therapy	XRT	
+P01	1160	1342	TREATMENT	Medical Therapy		CCNU + thalidomide
+P04	488	518	TREATMENT	Radiation Therapy	XRT	
+P04	488	700	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P04	1111	1279	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P05	562	928	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P06	0	176	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P07	47	86	TREATMENT	Radiation Therapy	XRT	
+P09	34	77	TREATMENT	Radiation Therapy	XRT	
+P10	0	273	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P11	29	71	TREATMENT	Radiation Therapy	XRT	
+P11	3038	3810	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P17	333	698	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P18	0	323	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P21	119	484	TREATMENT	Medical Therapy	Chemotherapy	TMZ
+P24	30	61	TREATMENT	Radiation Therapy	XRT	
+P24	2650	3007	TREATMENT	Medical Therapy	Chemotherapy	TMZ


### PR DESCRIPTION
I noticed the dates were swapped for these two treatment intervals for P04, so fixing that.

Except it's showing up as if I updated the whole file - not sure why. All I did was swap the two treatments starting on day 488 for P04 so that the long interval is for TMZ and the short one is XRT.