### PR TITLE
add HLA data to skcm_mskcc_2014

### DIFF
--- a/public/skcm_mskcc_2014/data_HLA.txt
+++ b/public/skcm_mskcc_2014/data_HLA.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f07c7385dcb1e63daa0130a2641344bed08f1c84cfc6f8e843c25f9a18e547a1
+size 9426

--- a/public/skcm_mskcc_2014/meta_HLA.txt
+++ b/public/skcm_mskcc_2014/meta_HLA.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: skcm_mskcc_2014
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: HLA
+datatype: CATEGORICAL
+stable_id: hla
+profile_name: HLA data
+profile_description: profile for HLA data
+data_filename: data_HLA.txt
+show_profile_in_analysis_tab: true
+patient_level: true
+generic_entity_meta_properties: NAME,DESCRIPTION


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/8829.

Cancer studies updated in this pull request:
- a
- .

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

