### PR TITLE
Fix ccle_broad_2019 oncotree codes

### DIFF
--- a/public/ccle_broad_2019/data_clinical_sample.txt
+++ b/public/ccle_broad_2019/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a6b80a58acce5784fbcfec35186bc97314e949e92e3d1e048189fca628c7000
-size 88
+oid sha256:aaff0fbb4b53cfbc4195040f65408bc19f577f43440560ff77f1a36e15658506
+size 579588


### PR DESCRIPTION
# What?
Fix #1392  .

The source [clinical data](https://depmap.org/portal/download/?release=CCLE+2019&release=Fusion&release=DNA+Copy+Number) already has mapped TCGA codes and some of the mappings seems to be not right. 

Here we have assigned the oncotree codes, cancer type and cancer type detailed based on the following clinical attributes:
1. Disease Subtype (new column added)
2. Histology
3. Lineage subtype (new column added)
4. Pathologist Annotation

Detailed mapping is here: https://docs.google.com/spreadsheets/d/1Up9gW2E1Kz9sgk10Iev2JHjaJOzDrNUMekvKuRy7MMY/edit#gid=146016842