### PR TITLE
brca_cptac_2020 GA format clean up 

### DIFF
--- a/public/brca_cptac_2020/data_acetylprotein_quantification.txt
+++ b/public/brca_cptac_2020/data_acetylprotein_quantification.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2d1f7189161a12269f9642a4d7dbdce7ce6ff4f541f5326f6e2f0fda8439434
-size 7735336
+oid sha256:1231e53847b40806d3dcd3f8076be9f2dda80e48669103e2ce2cd2fb908b1e9c
+size 7677312

--- a/public/brca_cptac_2020/data_phosphoprotein_quantification.txt
+++ b/public/brca_cptac_2020/data_phosphoprotein_quantification.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64c21de4843101bfefbf413a11c15ed08bf819d8bd14f00328490797a67e2887
-size 32084356
+oid sha256:aef2c0d99e94a3b93a5aef12a4d98a300d7fbaa19e84645d6e7e89fa831a533d
+size 31833718


### PR DESCRIPTION
reformat GA (removed duplicate gene symbol in description/separate multiple sites with underscore