### PR TITLE
aml_ohsu_2018: fix tumor_seq_allele1 column

### DIFF
--- a/public/aml_ohsu_2018/data_mutations.txt
+++ b/public/aml_ohsu_2018/data_mutations.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3de9c34e1550e5efaa6c547993b3de76cc835e29fe921a2c32e3bbd2bc000583
-size 4361652
+oid sha256:b9a00cb0ee062485a5fed779bc1369eb89fe4c8d9c4e2389d079c7caf4f28f1e
+size 4357313


### PR DESCRIPTION
# What?
Updated Tumor_seq_allele1 column to be same as the reference allele. 