### PR TITLE
Files with single cell data for gbm_cptac_2021 study

### DIFF
--- a/public/gbm_cptac_2021/case_lists/cases_single_cell_data.txt
+++ b/public/gbm_cptac_2021/case_lists/cases_single_cell_data.txt
@@ -1,0 +1,6 @@
+cancer_study_identifier: gbm_cptac_2021
+stable_id: gbm_cptac_2021_single_cell_data
+case_list_name: Samples with single cell RNA sequencing
+case_list_description: Samples with single cell RNA sequencing data available 
+case_list_category: all_cases_with_single_cell_data
+case_list_ids:C3L-02705 C3L-03968   C3N-01334   C3N-01814   C3N-01816   C3N-02188   C3N-02783   C3N-03184   C3N-03188   C3L-03405   C3N-00662   C3N-01798   C3N-01815   C3N-02181   C3N-02190   C3N-02769   C3N-02784   C3N-03186

--- a/public/gbm_cptac_2021/data_single_cell_phase.txt
+++ b/public/gbm_cptac_2021/data_single_cell_phase.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d8326f2ca0b72c8636ba4622faddf1846902db16cabc17a00598eb6a51601b3
+size 822

--- a/public/gbm_cptac_2021/data_single_cell_type.txt
+++ b/public/gbm_cptac_2021/data_single_cell_type.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:266d156b962705479532ffd6993be3d335dd57931c2898607f9b0458a5d31371
+size 1318

--- a/public/gbm_cptac_2021/meta_single_cell_cycle_phases.txt
+++ b/public/gbm_cptac_2021/meta_single_cell_cycle_phases.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: gbm_cptac_2021
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: SINGLE_CELL_CYCLE_PHASES
+datatype: LIMIT-VALUE
+stable_id: single_phases
+profile_name: Single cell - cell cycle phase values
+profile_description: Cell growth phase assignments
+data_filename: data_single_cell_phase.txt
+show_profile_in_analysis_tab: false
+pivot_threshold_value: 0.1
+value_sort_order: ASC
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/gbm_cptac_2021/meta_single_cell_type_frac.txt
+++ b/public/gbm_cptac_2021/meta_single_cell_type_frac.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: gbm_cptac_2021
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: SINGLE_CELL_TYPE_FRACTIONS
+datatype: LIMIT-VALUE
+stable_id: single_cell_type
+profile_name: Single cell - cell type assignment fractions
+profile_description: Cell type assignments
+data_filename: data_single_cell_type.txt
+show_profile_in_analysis_tab: false
+pivot_threshold_value: 0.1
+value_sort_order: ASC
+generic_entity_meta_properties: NAME,DESCRIPTION,URL


### PR DESCRIPTION
# What?
Fix #1595 

Cancer studies updated in this pull request:
- gbm_cptac_2021 

# checks
For all pull requests:
- [x] Passes validation

The team at MSK and The Hyve are working on developing a feature where a custom tab is enabled in the Patient view page that shows single-cell data. This gbm_cptac_2021 study has single-cell data available for 18 patients. The last step to making this production-ready is adding some generic assay data to link the cBioPortal study to the corresponding single-cell data. (https://github.com/cBioPortal/cbioportal/issues/9246)

The files I have added are:
gbm_cptac_2021/case_lists/cases_single_cell_data.txt
gbm_cptac_2021/data_single_cell_phase.txt
gbm_cptac_2021/data_single_cell_type.txt
gbm_cptac_2021/meta_single_cell_cycle_phases.txt
gbm_cptac_2021/meta_single_cell_type_frac.txt