### PR TITLE
fix sarc gene panel for missing stable_id

### DIFF
--- a/reference_data/gene_panels/data_gene_panel_sarc_mskcc.txt
+++ b/reference_data/gene_panels/data_gene_panel_sarc_mskcc.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27d79aa3b3c4609f417715acf6d0a642bcbd34a003f3f29bb6862164cba5fde7
-size 1344
+oid sha256:36a935384f1172a9e138b2d6edcd12b9dfc31d1c1f3105803b341ea0a6856416
+size 1373


### PR DESCRIPTION
Sarc gene panel was broken (https://github.com/cBioPortal/datahub/issues/1662)
Fixed according to the gene panel listed in https://github.com/cBioPortal/datahub/blob/master/public/sarc_mskcc/data_gene_panel_matrix.txt