### PR TITLE
lung_nci_2022: add gene panel matrix file

### DIFF
--- a/public/lung_nci_2022/data_gene_panel_matrix.txt
+++ b/public/lung_nci_2022/data_gene_panel_matrix.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fc7ac26b121f20f90656ad67fff2a20796b345f69496bb2cc371941422c17df
+size 5143

--- a/public/lung_nci_2022/meta_gene_panel_matrix.txt
+++ b/public/lung_nci_2022/meta_gene_panel_matrix.txt
@@ -1,0 +1,4 @@
+cancer_study_identifier: lung_nci_2022
+genetic_alteration_type: GENE_PANEL_MATRIX
+datatype: GENE_PANEL_MATRIX
+data_filename: data_gene_panel_matrix.txt


### PR DESCRIPTION
# What?
Fix # .

Cancer studies updated in this pull request:
- a
- .

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

