### PR TITLE
Add more H&E slides and one mpIF for msk_spectrum_tme_2022

### DIFF
--- a/public/msk_spectrum_tme_2022/data_resource_definition.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd2734b810fde1a6090044c297a6ed94443eef70973856bd669c573e88ea1ae6
-size 113
+oid sha256:3ccb7dfd1c3e9710bd5d2692a0ef8200c113941d832e953a9165fa9bce9b75d9
+size 174

--- a/public/msk_spectrum_tme_2022/data_resource_patient.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_patient.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8ee3d4e04bb27e72fd6fd7bc0735c0bb93e53e934462d310293d03a2e2639ee
+size 82

--- a/public/msk_spectrum_tme_2022/data_resource_sample.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b469d49ab7e371336ba44aa449ddfb0e79ecf2fdc12a445b0abe340ec91091e9
-size 2589
+oid sha256:dc6332512fe594baef7b9e044b2560d929290d1e5ecf22137734899fe874ad21
+size 4357

--- a/public/msk_spectrum_tme_2022/meta_resource_patient.txt
+++ b/public/msk_spectrum_tme_2022/meta_resource_patient.txt
@@ -1,0 +1,3 @@
+cancer_study_identifier: msk_spectrum_tme_2022
+resource_type: PATIENT
+data_filename: data_resource_patient.txt


### PR DESCRIPTION
This is for msk_spectrum_tme_2022. Adds slides for all samples

Notes:

- some samples point to the same slide (I guess they did MSK-IMPACT + WGS on the same tissue in those cases). We don't have a good way to visualize this at the moment so I only connected them to one for now. They are easy to find (samples with same `MSK Slide ID`)