### PR TITLE
Mutational signatures generated for studies (do not merge)

### DIFF
--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_DBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecda49f9582c13ed0b2f8d794f34d077684475517b06e825ae21d394b9e7fa9c
+size 8963

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_ID.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75af5385b6d07c1aaf560f52a3ca26d63c01d192a89e5d42c27a8970fcf2c05e
+size 28900

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_SBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:554e7be18f40906885e7824668865d912d1f6e34952a2d76b3bf186098528b2c
+size 165817

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_DBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c263bf23e5397fd0101445ac586ef4c5099a9807aecae06d45c18cad7f677c
+size 18873

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_ID.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4622128f829128c47d44eb63e1cdff39200df855688e7ea691fd8414ef0fae2e
+size 20660

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_SBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a6516e63833895800d1280ee9fba1764a2eeef6e3f7a044a35997b358f3e5c5
+size 23446

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_DBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a6c8448122d67c2af4f44822bfaee6aca32c7dc9988ddf6326e3202334463f5
+size 7464

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_ID.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b446a23aca05e7489600ad31c42662c47a0264fb9f64db7591503c8d4d495c7
+size 13589

--- a/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_SBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:564bb2d3899198bbe90938579482d5bd2a2c41b9f7d3326ad33630120911858e
+size 59951

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_DBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_DBS
+profile_name: mutational signature contribution DBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_contribution_DBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_ID.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_ID.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_ID
+profile_name: mutational signature contribution ID
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_contribution_ID.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_SBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_SBS
+profile_name: mutational signature contribution SBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_contribution_SBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_DBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_DBS
+profile_name: mutational signature matrix DBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_matrix_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_ID.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_ID.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_ID
+profile_name: mutational signature matrix ID
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_matrix_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_SBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_SBS
+profile_name: mutational signature matrix SBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_matrix_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_DBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_DBS
+profile_name: mutational signature pvalue DBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_pvalue_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_ID.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_ID
+profile_name: mutational signature pvalue ID
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_pvalue_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_SBS.txt
+++ b/public/acc_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: acc_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_SBS
+profile_name: mutational signature pvalue SBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_pvalue_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_contribution_DBS.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87d452f47f9cdcb7364d48490e03049ef99d92a013d5c1264350f9fa171df03e
+size 224833

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_contribution_ID.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_contribution_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0190aa446025457627e4fb7b0683d1ceb212c90b2fa73ed0b433ec88c3f3f71
+size 434760

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_contribution_SBS.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce92a59d00fadb5940f6e3aef6f1f126e5793e11fb34936884e01b20fd1f24a
+size 1890873

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_matrix_DBS.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00c668b429c21677594e01be1c46240cd07a405de8180ad0b398a2e5a59d07c
+size 213290

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_matrix_ID.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_matrix_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20039855f8b42bea7837fe2466d7f7e69acf50612eb340498bfc4e10cd4a3584
+size 225587

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_matrix_SBS.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4805674aea6ab0b06608cb5abe5840f4fb529336568025ed819f6b366e447d17
+size 264751

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_pvalue_DBS.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:914e95ab73f24095f2b15d025c38db66acb362b317f304d9583aeb7f36138f4a
+size 86840

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_pvalue_ID.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40482a64f97e00e50ed553b5bd510014c8384e1e4e2865d59795ce96b1cd409d
+size 131493

--- a/public/nsclc_tcga_broad_2016/data_mutational_signature_pvalue_SBS.txt
+++ b/public/nsclc_tcga_broad_2016/data_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1c0c989a8d94d627171965bd703188828ff00445809c9174e9bf98efc82a685
+size 477237

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_contribution_DBS.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_DBS
+profile_name: mutational signature contribution DBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_contribution_DBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_contribution_ID.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_contribution_ID.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_ID
+profile_name: mutational signature contribution ID
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_contribution_ID.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_contribution_SBS.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_SBS
+profile_name: mutational signature contribution SBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_contribution_SBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_matrix_DBS.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_DBS
+profile_name: mutational signature matrix DBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_matrix_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME
+value_sort_order: DESC

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_matrix_ID.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_matrix_ID.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_ID
+profile_name: mutational signature matrix ID
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_matrix_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME
+value_sort_order: DESC

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_matrix_SBS.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_SBS
+profile_name: mutational signature matrix SBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_matrix_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME
+value_sort_order: DESC

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_pvalue_DBS.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_DBS
+profile_name: mutational signature pvalue DBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_pvalue_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_pvalue_ID.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_ID
+profile_name: mutational signature pvalue ID
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_pvalue_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC

--- a/public/nsclc_tcga_broad_2016/meta_mutational_signature_pvalue_SBS.txt
+++ b/public/nsclc_tcga_broad_2016/meta_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: nsclc_tcga_broad_2016
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_SBS
+profile_name: mutational signature pvalue SBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_pvalue_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC

--- a/public/pancan_pcawg_2020/data_mutational_signature_contribution_DBS.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76ca4c06548f74be89e9d8c193feb0008afa0e09f232bbd3c00b78e1f7dfa7c7
+size 188492

--- a/public/pancan_pcawg_2020/data_mutational_signature_contribution_ID.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_contribution_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9a5e6012c2455a85ddb96bc2d69ffcb52eeb26bb578a6241863d9d9f52c0be8
+size 764518

--- a/public/pancan_pcawg_2020/data_mutational_signature_contribution_SBS.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6e16f76d82c910fb6df84e5c456bb24bc533d3f246b3c96c023f8db499bb19e
+size 4342754

--- a/public/pancan_pcawg_2020/data_mutational_signature_matrix_DBS.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c965ef6484d8a67ba26b04ab32b50ebadaa03d926840522cd748dba26ad3b718
+size 444674

--- a/public/pancan_pcawg_2020/data_mutational_signature_matrix_ID.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_matrix_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6584fe762958faa4927154471cc3183261f5764f805881a6da06894ab75f3e7e
+size 472394

--- a/public/pancan_pcawg_2020/data_mutational_signature_matrix_SBS.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10ce89ffdf68f7f4dee41ef7f8124aab087f7188946dc36e9a7625bee8434b3c
+size 546845

--- a/public/pancan_pcawg_2020/data_mutational_signature_pvalue_DBS.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3d65ff3f32bb4d1ff0c8961bffb477a97963f6a18f45c32d90a7b187e79000f
+size 126143

--- a/public/pancan_pcawg_2020/data_mutational_signature_pvalue_ID.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4df675163069588ab818273acea3dd98542fe7efd79904c54c6280d5b14d891f
+size 269275

--- a/public/pancan_pcawg_2020/data_mutational_signature_pvalue_SBS.txt
+++ b/public/pancan_pcawg_2020/data_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:629ff75d1722ff943e7bdbc592ce2ef51dbea9e49f2cd3f19ddcfc640c7ec0c5
+size 1269835

--- a/public/pancan_pcawg_2020/meta_mutational_signature_contribution_DBS.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_DBS
+profile_name: mutational signature contribution DBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_contribution_DBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/pancan_pcawg_2020/meta_mutational_signature_contribution_ID.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_contribution_ID.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_ID
+profile_name: mutational signature contribution ID
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_contribution_ID.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/pancan_pcawg_2020/meta_mutational_signature_contribution_SBS.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_SBS
+profile_name: mutational signature contribution SBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_contribution_SBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/pancan_pcawg_2020/meta_mutational_signature_matrix_DBS.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_DBS
+profile_name: mutational signature matrix DBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_matrix_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME

--- a/public/pancan_pcawg_2020/meta_mutational_signature_matrix_ID.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_matrix_ID.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_ID
+profile_name: mutational signature matrix ID
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_matrix_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME

--- a/public/pancan_pcawg_2020/meta_mutational_signature_matrix_SBS.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_SBS
+profile_name: mutational signature matrix SBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_matrix_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME

--- a/public/pancan_pcawg_2020/meta_mutational_signature_pvalue_DBS.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_DBS
+profile_name: mutational signature pvalue DBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_pvalue_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/pancan_pcawg_2020/meta_mutational_signature_pvalue_ID.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_ID
+profile_name: mutational signature pvalue ID
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_pvalue_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/pancan_pcawg_2020/meta_mutational_signature_pvalue_SBS.txt
+++ b/public/pancan_pcawg_2020/meta_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: pancan_pcawg_2020
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_SBS
+profile_name: mutational signature pvalue SBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 1000 permutations
+data_filename: data_mutational_signature_pvalue_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_DBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ade6874703445b10fd9e82da5ac4f5eea8b3ce4504234029a774b82833d0a1ba
+size 94544

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_ID.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32f83b61858028c0308019fcb6546a706beedcef8635ebc4b31e67412ea7b011
+size 134856

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_SBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36b156cf26a274866bd9a328f7793da9bc8af92f22001319ce420f00364e9928
+size 739235

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_DBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a30520001834f00f6f9278dae8015707d7b4eb9e457718f961d96d06f2b153a
+size 79159

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_ID.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c34c9e48b1480c710121cc55c67a1851cb77cd34aa21b52d57de77ad20585dd5
+size 84174

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_SBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dafbf84f7a976f3b1faf36939c522abb1bb7151b418ef044697d04bf9d1453c2
+size 102408

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_DBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4eddc243fa947a5e4475c39b0b651bace447d5f210f5a8eb77c27c3a3a92adad
+size 30908

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_ID.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d27ead39bdffc002948167fd2fb52ba157f182b815a687ac913bd8e02058138
+size 45289

--- a/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_SBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/data_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:369e5f73ae15aa37e9caa82a14eb471fa9fdba5f9c5582297fc31229bf30bb4b
+size 189254

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_DBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_DBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_DBS
+profile_name: mutational signature contribution DBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_contribution_DBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_ID.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_ID.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_ID
+profile_name: mutational signature contribution ID
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_contribution_ID.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_SBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_contribution_SBS.txt
@@ -1,0 +1,12 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_contribution_SBS
+profile_name: mutational signature contribution SBS
+profile_description: profile for contribution value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_contribution_SBS.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC
+pivot_threshold_value: 0.05

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_DBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_DBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_DBS
+profile_name: mutational signature matrix DBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_matrix_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME
+value_sort_order: DESC

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_ID.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_ID.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_ID
+profile_name: mutational signature matrix ID
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_matrix_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME
+value_sort_order: DESC

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_SBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_matrix_SBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_matrix_SBS
+profile_name: mutational signature matrix SBS
+profile_description: profile for matrix value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_matrix_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME
+value_sort_order: DESC

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_DBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_DBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_DBS
+profile_name: mutational signature pvalue DBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_pvalue_DBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_ID.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_ID.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_ID
+profile_name: mutational signature pvalue ID
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_pvalue_ID.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC

--- a/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_SBS.txt
+++ b/public/skcm_tcga_pan_can_atlas_2018/meta_mutational_signature_pvalue_SBS.txt
@@ -1,0 +1,11 @@
+cancer_study_identifier: skcm_tcga_pan_can_atlas_2018
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: MUTATIONAL_SIGNATURE
+datatype: LIMIT-VALUE
+stable_id: mutational_signature_pvalue_SBS
+profile_name: mutational signature pvalue SBS
+profile_description: profile for pvalue value of mutational signatures, generated using tempoSig with 100 permutations
+data_filename: data_mutational_signature_pvalue_SBS.txt
+show_profile_in_analysis_tab: false
+generic_entity_meta_properties: NAME,DESCRIPTION,URL
+value_sort_order: DESC


### PR DESCRIPTION
Preview PR (not for actual merging)
Mutational signatures extracted from cBioPortal MAF files. 
*These mutational signature profiles are purely for demonstration and this is not a good practice for generating mutational signatures, as MAF files are curated and do not reflect a full mutational spectrum.*

Studies with mutational signatures:
- acc_tcga_pan_can_atlas_2018
- nsclc_tcga_broad_2016
- pancan_pcawg_2020
- skcm_tcga_pan_can_atlas_2018 

Smoking history vs SBS4 (Smoking) - `nsclc_tcga_broad_2016`
![image](https://user-images.githubusercontent.com/63122826/223432272-6e504163-c7c1-49f0-ae9e-983b8b77efc7.png)

UV signatures high in contribution and significant (determined with 100 permutations) - `skcm_tcga_pan_can_atlas_2018`
![image](https://user-images.githubusercontent.com/63122826/223432709-2c576b5b-3a35-4ffe-bcc7-10053eb48fb3.png)

This is the datahub preview of [RFC64](https://docs.google.com/document/d/1evzgJ8DiU4o46dWxnQH7yOm1wXMV6GZvElnupI7n0Cg/edit?usp=sharing).

Related front-end PR https://github.com/cBioPortal/cbioportal-frontend/pull/4540 containing the front-end implementation.
Related back-end PR https://github.com/cBioPortal/datahub-study-curation-tools/pull/48 containing the script used for mutational-signature extraction and metafile generation