### PR TITLE
fix arm-level NA's

### DIFF
--- a/public/luad_tcga_pan_can_atlas_2018/data_armlevel_cna.txt
+++ b/public/luad_tcga_pan_can_atlas_2018/data_armlevel_cna.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:479f7eb806dbd81df943595d88f2789196dd4ccdf43ffd175e264315588faf54
-size 170106
+oid sha256:a62fd3b53b0f8f3d6297c0df9b6d83aaf31bffe2eb646d9c056c94d8c2f3fda2
+size 155525


### PR DESCRIPTION
#1818
The arm-level data was missing gains in the data file and it was fixed with the right data in the PR. This is coz of  a typo error while importing.

Cancer studies updated in this pull request:
- luad_tcga_pan_can_atlas_2018