### PR TITLE
Fix GSVA p-value filepointer

### DIFF
--- a/public/coad_silu_2022/meta_gsva_pvalues.txt
+++ b/public/coad_silu_2022/meta_gsva_pvalues.txt
@@ -5,5 +5,5 @@ stable_id: gsva_pvalues
 source_stable_id: gsva_scores
 profile_name: ssGSVA scores on immunologic and oncogenic signatures
 profile_description: ssGSVA scores on immunologic and oncogenic signatures gene sets using mRNA expression data calculated with ssGSVA
-data_filename: meta_gsva_pvalues.txt
+data_filename: data_gsva_pvalues.txt
 geneset_def_version: msigdb_7.5.1


### PR DESCRIPTION
# What?
The file `meta_gsva_pvalues.txt` points to itself as datafile. Changed to point to the actual datafile. 

Cancer studies updated in this pull request:
- coad_silu_2022

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

