### PR TITLE
Add preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,105 @@
+on:
+    pull_request:
+      branches:
+        - "*"
+
+jobs:
+    changed_files:
+      runs-on: ubuntu-latest
+      outputs:
+        new_study_dirs: ${{ steps.new-dirs.outputs.NEW_DIR_LOCATIONS }}
+      steps:
+        - name: Get New Directories Added
+          id: changed-files-dir-names
+          uses: tj-actions/changed-files@v38
+          with:
+            dir_names: "true"
+  
+        - name: Extract Parent Directory Names of New Studies
+          id: new-dirs
+          shell: bash
+          run: |
+            echo "NEW_DIR_LOCATIONS=$( echo ${{ steps.changed-files-dir-names.outputs.added_files }} | sed 's/[^ ]*\/case_lists[^ ]*//g' )" >> $GITHUB_OUTPUT
+  
+    preview:
+      needs: changed_files
+      runs-on: ubuntu-latest
+      container: docker.io/okteto/okteto:2.19.1
+      steps:
+        - name: Install Git LFS
+          run: apk update && apk add git-lfs
+  
+        - name: Split Directories Into New Line Pattern For Sparse Checkout
+          id: split
+          run: |
+            echo "STUDY_DIRS<<EOF" >> $GITHUB_ENV
+            echo "$( echo ${{ needs.changed_files.outputs.new_study_dirs }} | tr ' ' '\n')" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+  
+        - name: Checkout Datahub Repository
+          uses: actions/checkout@v4
+          with:
+            lfs: true
+            sparse-checkout-cone-mode: false
+            sparse-checkout: |
+              preview/*
+              ${{ env.STUDY_DIRS }}
+  
+        - name: Copy New Files to Study Directory
+          shell: bash
+          run: |
+            for dir in ${{ needs.changed_files.outputs.new_study_dirs }}; do
+              study_name=$( cut -d "/" -f2- <<< ${dir}) # remove 'public/' from string
+              cp -v -R ${dir} preview/cbioportal-docker-compose/study/${study_name}
+            done
+  
+        - name: Context
+          uses: okteto/context@latest
+          with:
+            url: ${{secrets.OKTETO_URL}}
+            token: ${{ secrets.OKTETO_TOKEN }}
+  
+        - name: Okteto Build to Import Studies
+          working-directory: preview/cbioportal-docker-compose
+          run: |
+            okteto build --no-cache -t okteto.dev/cbioportal-docker-compose-cbioportal:okteto-with-volume-mounts cbioportal
+  
+        - name: Deploy Preview Environment
+          uses: okteto/deploy-preview@latest
+          env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            name: pr-${{ github.event.number }}-justinjao
+            file: preview/cbioportal-docker-compose/docker-compose.yml
+            timeout: 15m
+      
+        - name: Wait For Response From Preview Instance
+          uses: nev7n/wait_for_response@v1.0.1
+          with:
+            url: 'https://cbioportal-pr-${{ github.event.number }}-justinjao.cloud.okteto.net/'
+            responseCode: 200
+            timeout: 600000 # 10 minutes
+            interval: 30000 # 30 seconds
+  
+        - name: Activate Namespace
+          uses: okteto/namespace@latest
+          with:
+            namespace: pr-${{github.event.number}}-justinjao
+  
+        - name: Run Metaimport Script to Import Study Using Kubectl
+          id: import-study
+          continue-on-error: true
+          shell: bash
+          run: |
+            okteto kubeconfig
+            for dir in ${{ needs.changed_files.outputs.new_study_dirs }}; do
+              study_name=$( cut -d "/" -f2- <<< ${dir})
+              kubectl exec -it deployment/cbioportal -- metaImport.py -u http://localhost:8080 -s study/${study_name} -o
+            done
+  
+        - name: Add PR Comment if Import Failed
+          uses: mainmatter/continue-on-error-comment@v1
+          with:
+              repo-token: ${{ secrets.GITHUB_TOKEN }}
+              outcome: ${{ steps.import-study.outcome }}
+              test-id: Error code 1

--- a/.github/workflows/preview_closed.yml
+++ b/.github/workflows/preview_closed.yml
@@ -1,0 +1,19 @@
+on:
+    pull_request:
+      types:
+        - closed
+ 
+jobs:
+    destroy-pr-env:
+      runs-on: ubuntu-latest
+      steps:
+      - name: Context
+        uses: okteto/context@latest
+        with:
+          token: ${{ secrets.OKTETO_TOKEN }}
+          url: ${{ secrets.OKTETO_URL }}
+  
+      - name: Destroy Preview Environment
+        uses: okteto/destroy-preview@latest
+        with:
+          name: pr-${{ github.event.number }}-justinjao

--- a/preview/cbioportal-docker-compose/.env
+++ b/preview/cbioportal-docker-compose/.env
@@ -1,0 +1,3 @@
+DOCKER_IMAGE_CBIOPORTAL=registry.cloud.okteto.net/justinjao/cbioportal-docker-compose-cbioportal:okteto-with-volume-mounts
+DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.1
+DOCKER_IMAGE_MYSQL=registry.cloud.okteto.net/justinjao/cbioportal-docker-compose-cbioportal-database:okteto-with-volume-mounts

--- a/preview/cbioportal-docker-compose/docker-compose.yml
+++ b/preview/cbioportal-docker-compose/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3'
+
+services:
+  cbioportal:
+    restart: unless-stopped
+    image: ${DOCKER_IMAGE_CBIOPORTAL}
+    container_name: cbioportal-container
+    environment:
+      SHOW_DEBUG_INFO: "true"
+    ports:
+      - "8080:8080"
+    volumes:
+     - ./study:/study/
+     - ./config/portal.properties:/cbioportal/portal.properties
+    depends_on:
+     - cbioportal-database
+     - cbioportal-session
+    networks:
+     - cbio-net
+    command: /bin/sh -c "java -Xms2g -Xmx4g -Dauthenticate=noauthsessionservice -Dsession.service.url=http://cbioportal-session:5000/api/sessions/my_portal/ -jar webapp-runner.jar -AmaxHttpHeaderSize=16384 -AconnectionTimeout=20000 --enable-compression /cbioportal-webapp"
+  cbioportal-database:
+    restart: unless-stopped
+    image: ${DOCKER_IMAGE_MYSQL}
+    container_name: cbioportal-database-container
+    environment:
+      MYSQL_DATABASE: cbioportal
+      MYSQL_USER: cbio_user
+      MYSQL_PASSWORD: somepassword
+      MYSQL_ROOT_PASSWORD: somepassword
+    volumes:
+     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql
+     - ./data/seed.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz
+     - cbioportal_mysql_data:/var/lib/mysql
+    networks:
+     - cbio-net
+  cbioportal-session:
+    restart: unless-stopped
+    image: ${DOCKER_IMAGE_SESSION_SERVICE}
+    container_name: cbioportal-session-container
+    environment:
+      SERVER_PORT: 5000
+      JAVA_OPTS: -Dspring.data.mongodb.uri=mongodb://cbioportal-session-database:27017/session-service
+    depends_on:
+      - cbioportal-session-database
+    networks:
+      - cbio-net
+  cbioportal-session-database:
+    restart: unless-stopped
+    image: mongo:4.2
+    container_name: cbioportal-session-database-container
+    environment:
+      MONGO_INITDB_DATABASE: session_service
+    volumes:
+      - cbioportal_mongo_data:/data/db
+    networks:
+      - cbio-net
+
+networks:
+  cbio-net: 
+  
+volumes:
+  cbioportal_mysql_data:
+  cbioportal_mongo_data:


### PR DESCRIPTION
# What?
Fix #1908

This PR constitutes the work done for the Google Summer of Code project for Justin Jao, as referenced [here](https://github.com/cBioPortal/GSoC/issues/84).

This adds a proposed workflow for automating the deployment of a staging environment upon PR creation to the datahub repo.

In particular:
* a `preview.yml` workflow file that triggers the automated deployment of the staging environment with the new studies imported
* a `preview_closed.yml` file that automatically tears down the deployed staging environment upon PR closure or merging.
* the directory and miscellaneous file infrastructure (located within the added `preview` directory) necessary to support this automated deployment
* documentation for this proposed workflow, located within the `documentation` directory

-----
Important Notes:
* This PR currently must undergo further discussion to determine which account will setup the Okteto infrastructure needed for this workflow to function
* After this has been determined, the namespace listed in the code will need to be changed accordingly within each of these files
* Before merging, certain steps, such as adding Okteto secrets, must be undertaken (documented in `Preview_Setup.md`) before the workflow will be fully functional 
* Currently, not all studies may be imported, as there is a known issue with gene panels IDs not being present in the seeded database. This may be fixed in a future update, but for now, a temporary stopgap has been placed (documented in `Preview_Overview.md`).
* For more information about this workflow, please see the produced documentation at `Preview_Overview.md`. 