### PR TITLE
add IDC OHIF viewer CT scans to TCGA for READ

### DIFF
--- a/public/coadread_tcga_pan_can_atlas_2018/data_resource_definition.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/data_resource_definition.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7937237210c5e2b3b35083f1ccb52f3ec6747b7c72e4f0a530897dfc321d25a3
+size 119

--- a/public/coadread_tcga_pan_can_atlas_2018/data_resource_patient.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/data_resource_patient.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ddcc391008825c1650bb3c057f0512d9730b2c97d4b794ab62318f0234b1051
+size 3459

--- a/public/coadread_tcga_pan_can_atlas_2018/meta_resource_definition.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/meta_resource_definition.txt
@@ -1,0 +1,3 @@
+cancer_study_identifier: coadread_tcga_pan_can_atlas_2018
+resource_type: DEFINITION
+data_filename: data_resource_definition.txt

--- a/public/coadread_tcga_pan_can_atlas_2018/meta_resource_patient.txt
+++ b/public/coadread_tcga_pan_can_atlas_2018/meta_resource_patient.txt
@@ -1,0 +1,3 @@
+cancer_study_identifier: coadread_tcga_pan_can_atlas_2018
+resource_type: PATIENT
+data_filename: data_resource_patient.txt


### PR DESCRIPTION
Partially address https://github.com/cBioPortal/datahub/issues/2011. This adds Imaging Data Common's OHIF viewer for CT scans in TCGA COAD

![image](https://github.com/cBioPortal/datahub/assets/1334004/bdc667af-b6b5-4486-b3e3-9224af5bf497)

Note: screenshot is out of sync (Changed the tab to say "CT Scan")
