### PR TITLE
brca_metabric: update relapse free survival data

### DIFF
--- a/public/brca_metabric/data_clinical_patient.txt
+++ b/public/brca_metabric/data_clinical_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f01fde122007c133af67fc92e2b50d569c63295fe9b8e7d65ea8e89afe5dc47f
-size 385858
+oid sha256:2a6bbadc6e4b2b07c0505559d438da959fc5c9aba55c7194abc394e2d6454995
+size 408387


### PR DESCRIPTION
# What?
The RFS data shared initially did not match the publication. The correct data was shared by the author. Compared data to publication and updated the clinical file. 