### PR TITLE
MSK IMPACT/HEME/ARCHER panels - update outdated gene symbols to latest

### DIFF
--- a/reference_data/gene_panels/data_gene_panel_archer_heme.txt
+++ b/reference_data/gene_panels/data_gene_panel_archer_heme.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:077c8e63887b4845f5ea3b28bf71668d6de0b9368eccf0a50c1605ea8682b915
-size 1275
+oid sha256:4c2eda29dfa990ed6e3f2456517d615ea8b70473adb27638afc5f5a6f7c1404b
+size 1273

--- a/reference_data/gene_panels/data_gene_panel_archer_solid.txt
+++ b/reference_data/gene_panels/data_gene_panel_archer_solid.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1561b5f313b0c8ea8746ca6d283b78cb312cea93e8ca489df689f75ce2a3f31
-size 478
+oid sha256:ff7c74c396f24b044ad60b1f5cdf24bb8e3326d5a9c23b24f55b7879ea5bf3aa
+size 477

--- a/reference_data/gene_panels/data_gene_panel_heme400.txt
+++ b/reference_data/gene_panels/data_gene_panel_heme400.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec6ac61206f138d4d91072d3b04d82d95ddcf5703776a88024ad99d2b2eb6a26
-size 2567
+oid sha256:d26e167dc539dd302a5b44f5e959a0f2bd48acc4a6dc8af0dcc22c0c8146a0b2
+size 2506

--- a/reference_data/gene_panels/data_gene_panel_heme468.txt
+++ b/reference_data/gene_panels/data_gene_panel_heme468.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7958d486a56c2bcb14bafd32f6155783e56fa97c5e0d9d519ab0859a39f8f1a3
-size 3046
+oid sha256:e35667df86c04576d8b8284dde44cfea585a58ee49b57927730a498232e031ef
+size 2987

--- a/reference_data/gene_panels/data_gene_panel_heme_hotspot.txt
+++ b/reference_data/gene_panels/data_gene_panel_heme_hotspot.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96f20ea7e018cd44590e75ec8c2f2eb794b750f17e7678137852bafe763b4dfd
+oid sha256:ba9b4f07ca189537d192d6fe88df3804b52b0f9ab914077cb97d750927d8d256
 size 1337

--- a/reference_data/gene_panels/data_gene_panel_impact230.txt
+++ b/reference_data/gene_panels/data_gene_panel_impact230.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e50adda3e32f1254b1a39d7dc2d1bb3b8b331dbd92da9f673e867fb2bff789aa
-size 1453
+oid sha256:eb18af8333a311a42899c835ad1ae84fc43bceef98e44ff93efb9a62c3f1755c
+size 1448

--- a/reference_data/gene_panels/data_gene_panel_impact279.txt
+++ b/reference_data/gene_panels/data_gene_panel_impact279.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5d1ea2045798a7b14b3022a805046ffdcdd630a955e6d9a1fb18a7d31f70326
-size 1797
+oid sha256:865f8134b897be7b0ce4026808b17d9dc8de00c54f0063e3031cd106d85d1e51
+size 1796

--- a/reference_data/gene_panels/data_gene_panel_impact300.txt
+++ b/reference_data/gene_panels/data_gene_panel_impact300.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95894b951f13d1e052325820b755455a16d77e9cfadf65c04c45a881adebd879
-size 1930
+oid sha256:f8d71d63bbbb8c88d3c3cc13f7dd3d3e03b4db017765af9f73bdd618bcd3e94a
+size 1924

--- a/reference_data/gene_panels/data_gene_panel_impact341.txt
+++ b/reference_data/gene_panels/data_gene_panel_impact341.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66f5af5747f095fc699021f37df13fb732e2dc02dbc16d6180a9a48a7757156a
-size 2165
+oid sha256:2d089c1305f7964a4f4e7746f2fd9135cbc3fe6ff1cafaf27eb3a55f8af7da0f
+size 2151

--- a/reference_data/gene_panels/data_gene_panel_impact410.txt
+++ b/reference_data/gene_panels/data_gene_panel_impact410.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9473f2734712f61f51b0099305fb779bf686597bd4c03c8e1d6cd7d76b0b499d
-size 2612
+oid sha256:cdb51eeebc0986a3c69bd6410009fe9323669c389432ab0a6846319c13eb34da
+size 2555

--- a/reference_data/gene_panels/data_gene_panel_impact468.txt
+++ b/reference_data/gene_panels/data_gene_panel_impact468.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f8a99fbb8943a76d72b30a732d691a867f474a237fd949a97d82be61db53cd6
-size 2961
+oid sha256:1d20d9412c9c05cdd96d576fdda61276f58cb7bb5bf293101a364541748db056
+size 2901

--- a/reference_data/gene_panels/data_gene_panel_impact505.txt
+++ b/reference_data/gene_panels/data_gene_panel_impact505.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fdfc530dc4da7400c5276ddac38782baf112d3170f6243a980a8b88f12f36ce
-size 3183
+oid sha256:9eeecc446e4fa8a7d4315b7416a8213172aae14e0fd0f5f7254cbc088d8570f2
+size 3122


### PR DESCRIPTION
# What?
A couple of gene symbols in the panels were outdated and have been updated to the latest symbols.

The list of symbols that were mapped to new symbols can be seen here: https://docs.google.com/spreadsheets/d/1e6pGueoR5VxldlC2t3MfgojgthQ61paCSlh7IuC8hBQ/edit#gid=0