### PR TITLE
add cell cycle phase counts and fractions as generic assay

### DIFF
--- a/public/msk_spectrum_tme_2022/data_cell_cycle_counts.txt
+++ b/public/msk_spectrum_tme_2022/data_cell_cycle_counts.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ba9e913a2b8290b89e008969698c1d6f69dfd3f9166ad2a382af2b73db72b59
+size 3037

--- a/public/msk_spectrum_tme_2022/data_cell_cycle_fraction.txt
+++ b/public/msk_spectrum_tme_2022/data_cell_cycle_fraction.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62f374ded05253ef11f0f93d1dc93b39734dc41f68fd8f995b6b4cc5cabb90ac
+size 6288

--- a/public/msk_spectrum_tme_2022/meta_absolute_counts.txt
+++ b/public/msk_spectrum_tme_2022/meta_absolute_counts.txt
@@ -1,6 +1,6 @@
 cancer_study_identifier: msk_spectrum_tme_2022
 genetic_alteration_type: GENERIC_ASSAY
-generic_assay_type: ABSOLUTE_COUNTS
+generic_assay_type: ABSOLUTE_CELL_TYPE_COUNTS
 datatype: LIMIT-VALUE
 stable_id: absolute_counts
 profile_name: Absolute Counts

--- a/public/msk_spectrum_tme_2022/meta_cell_cycle_counts.txt
+++ b/public/msk_spectrum_tme_2022/meta_cell_cycle_counts.txt
@@ -1,0 +1,13 @@
+cancer_study_identifier: msk_spectrum_tme_2022
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: CELL_CYCLE_COUNTS
+datatype: LIMIT-VALUE
+stable_id: cell_cycle_stage_absolute_counts
+profile_name: Absolute Counts
+profile_description: Absolute Counts.
+data_filename: data_cell_cycle_counts.txt
+show_profile_in_analysis_tab: true 
+pivot_threshold_value: 0
+value_sort_order: DESC
+patient_level: false
+generic_entity_meta_properties: DESCRIPTION

--- a/public/msk_spectrum_tme_2022/meta_cell_cycle_fraction.txt
+++ b/public/msk_spectrum_tme_2022/meta_cell_cycle_fraction.txt
@@ -1,0 +1,13 @@
+cancer_study_identifier: msk_spectrum_tme_2022
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: RELATIVE_CELL_CYCLE_COUNTS
+datatype: LIMIT-VALUE
+stable_id: cell_cycle_stage
+profile_name: Relative Fraction
+profile_description: Relative Fraction.
+data_filename: data_cell_cycle_fraction.txt
+show_profile_in_analysis_tab: true 
+pivot_threshold_value: 0.0
+value_sort_order: DESC
+patient_level: false
+generic_entity_meta_properties: DESCRIPTION

--- a/public/msk_spectrum_tme_2022/meta_relative_fraction.txt
+++ b/public/msk_spectrum_tme_2022/meta_relative_fraction.txt
@@ -1,6 +1,6 @@
 cancer_study_identifier: msk_spectrum_tme_2022
 genetic_alteration_type: GENERIC_ASSAY
-generic_assay_type: RELATIVE_COUNTS
+generic_assay_type: RELATIVE_CELL_TYPE_COUNTS
 datatype: LIMIT-VALUE
 stable_id: relative_counts
 profile_name: Relative Counts


### PR DESCRIPTION
# What?

Add cell cycle generic assay meta and data for cell cycle phase (counts and fractions), update the meta files for cell type counts and fractions.
Cell cycle phase assignment data was pulled from cellxgene for this study, similar to cell type assignment.
All four generic assay data (cell cycle counts and fractions, cell type counts and fractions) will be used by the GSoC intern to develop visualization for single cell data. 
Cancer studies updated in this pull request:
- msk_spectrum_tme_2022


# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

