### PR TITLE
laud_oncosg_2020: remove raw RSEM profile

### DIFF
--- a/public/luad_oncosg_2020/data_mrna_seq_v2_rsem.txt
+++ b/public/luad_oncosg_2020/data_mrna_seq_v2_rsem.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da2792dc68926bdef46451c4b3f6ecd665f36c2b5699555b1d180bb38cf465af
-size 61297561

--- a/public/luad_oncosg_2020/meta_mrna_seq_v2_rsem.txt
+++ b/public/luad_oncosg_2020/meta_mrna_seq_v2_rsem.txt
@@ -1,8 +1,0 @@
-cancer_study_identifier: luad_oncosg_2020
-genetic_alteration_type: MRNA_EXPRESSION
-datatype: CONTINUOUS
-stable_id: rna_seq_v2_mrna
-show_profile_in_analysis_tab: false
-profile_name: mRNA expression (log RNA Seq V2 RSEM)
-profile_description: Expression levels (log RNA Seq V2 RSEM)(Raw read counts were normalized using DESeq2(v.1.16.1) followed by log transformation (adding one pseudo-count and log2 transformation)).
-data_filename: data_mrna_seq_v2_rsem.txt


### PR DESCRIPTION
Based on the [user](https://groups.google.com/g/cbioportal/c/7asP7dDM7fU) issue, the RSEM data and the zscore profiles are identical. From the [data source](https://www.nature.com/articles/s41588-019-0569-6) and [OncoSG portal](https://src.gisapps.org/OncoSG_public/study/summary?id=GIS031) it is identified that the expression counts estimated from RSEM were normalized using DESeq2 v.1.16.1 followed by log transformation (adding one pseudo-count and log2 transformation) and the data appears to be zscore normalized. 