### PR TITLE
Fix GitHub Actions spec for zip_studies

### DIFF
--- a/.github/workflows/zip_studies.yml
+++ b/.github/workflows/zip_studies.yml
@@ -27,7 +27,7 @@ jobs:
                 set["crdc/gdc/" parts[3]]++;
             }
         } 
-        END { for (studypath in set) { print studypath } }'"
+        END { for (studypath in set) { print studypath } }')"
         exit 0
       id: unique_studies
     - uses: actions/checkout@v2
@@ -60,14 +60,14 @@ jobs:
         tar -cvf ${SAVED_GIT_REPO_FILENAME} .git > /dev/null
         mkdir studies_to_upload
         for study_path in ${{ steps.unique_studies.outputs.unique_study_paths_list }}; do
-          if [ ! -d "${changed_study}" ]; then
+          if [ ! -d "${study_path}" ]; then
             continue
           fi
           changed_study=$(basename "$study_path")
           echo "Pulling study: ${study_path}."
           git lfs pull --include="${study_path}"
           echo "Compressing this study: ${study_path}."
-          tar -czvf studies_to_upload/${changed_study}.tar.gz ${changed_study}
+          tar -czvf studies_to_upload/${changed_study}.tar.gz ${study_path}
           echo "Copy file to S3: studies_to_upload/${changed_study}.tar.gz"
           aws s3 cp --acl public-read studies_to_upload/${changed_study}.tar.gz s3://${AWS_S3_BUCKET}/
           echo "Remove this directory: ${study_path}."


### PR DESCRIPTION
The main culprit was the missing parentheses, I also double-checked my changes from #2048 and fixed some variables that I had forgotten to update. /cc @rmadupuri

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

