### PR TITLE
Do not nest studies inside tarballs

### DIFF
--- a/.github/workflows/zip_all_studies.yml
+++ b/.github/workflows/zip_all_studies.yml
@@ -42,10 +42,11 @@ jobs:
             continue
           fi
           study=$(basename "$studypath")
+          study_dir=$(dirname "$studypath")
           echo "Pulling study: ${studypath}."
           git lfs pull --include="${studypath}"
           echo "Compressing this study: ${studypath}."
-          tar -czvf studies_to_upload/${study}.tar.gz ${studypath}
+          tar -czvf studies_to_upload/${study}.tar.gz -C ${study_dir} ${study}
           echo "Copy file to S3: studies_to_upload/${study}.tar.gz"
           aws s3 cp --acl public-read studies_to_upload/${study}.tar.gz s3://${AWS_S3_BUCKET}/
           echo "Remove this directory: ${studypath}."

--- a/.github/workflows/zip_studies.yml
+++ b/.github/workflows/zip_studies.yml
@@ -64,10 +64,11 @@ jobs:
             continue
           fi
           changed_study=$(basename "$study_path")
+          study_dir=$(dirname "$study_path")
           echo "Pulling study: ${study_path}."
           git lfs pull --include="${study_path}"
           echo "Compressing this study: ${study_path}."
-          tar -czvf studies_to_upload/${changed_study}.tar.gz ${study_path}
+          tar -czvf studies_to_upload/${changed_study}.tar.gz -C ${study_dir} ${changed_study}
           echo "Copy file to S3: studies_to_upload/${changed_study}.tar.gz"
           aws s3 cp --acl public-read studies_to_upload/${changed_study}.tar.gz s3://${AWS_S3_BUCKET}/
           echo "Remove this directory: ${study_path}."


### PR DESCRIPTION
# What?
This fixes a regression from #2048 and ensures the GitHub Actions to zip studies will not nest them under `public/` or `crdc/gdc/` within the tarball.

cc @rmadupuri 

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] is study meta data complete? e.g. pmid, group of PUBLIC
- [ ] were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] clinical sample and patient data with meta files
- [ ] mutations data with meta files
- [ ] MAF is based on hg19
- [ ] MAF with 2 isoforms: uniprot and mskcc
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Case-lists for all profiles.
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

