### PR TITLE
Fix to circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
   workflow_weekly:
     triggers:
       - schedule:
-          cron: "0 16 * * 6"
+          cron: "30 14 * * 1"
           filters:
             branches:
               only: 

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.32.3
+requests==2.27.1
 Jinja2==3.1.4
 mysqlclient==1.3.13
 docker==3.5.0

--- a/.circleci/validate_all_studies.sh
+++ b/.circleci/validate_all_studies.sh
@@ -11,7 +11,7 @@ git lfs pull -I "public"
 num_studies=${#list_of_study_dirs[@]}
 
 test_reports_location="$HOME/test-reports"
-validation_command="$HOME/cbioportal-core/src/main/resources/scripts/importer/./validateStudies.py -d $HOME/repo/public/ -p $HOME/repo/.circleci/portalinfo -html $test_reports_location"
+validation_command="$HOME/cbioportal-core/scripts/importer/./validateStudies.py -d $HOME/repo/public/ -p $HOME/repo/.circleci/portalinfo -html $test_reports_location"
 echo $'\nExecuting: '; echo $validation_command
 if sh -c "$validation_command" ; then
     echo "Tests passed successfully"


### PR DESCRIPTION
The [weekly validation test](https://app.circleci.com/pipelines/github/cBioPortal/datahub?branch=master) failed due to the validator path not being found after the switch to `cbioportal-core`.
- Fixed the validator path
- Resolved an issue with downloading the latest requests module by updating it to version 2.27.1, which CircleCI recognizes.
- Temporarily updated the cron schedule to trigger in the next 15 minutes for testing (will revert to weekly runs afterward).