### PR TITLE
Re-calculated TMB scores

### DIFF
--- a/public/bowel_colitis_msk_2022/data_clinical_sample.txt
+++ b/public/bowel_colitis_msk_2022/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d9ef919038dc41b48f9fe8090bfe0217f4e1a6c52636c9749ed843a242d023c
-size 50981
+oid sha256:d541bddf62cf7b57799ca1e35304fb125c3e5ee9fd49f17f82541d3107c66c1e
+size 50996

--- a/public/egc_msk_tp53_ccr_2022/data_clinical_sample.txt
+++ b/public/egc_msk_tp53_ccr_2022/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdb1c86a94556350ccb5be61966d4f0c9cc23e74ba0178bb028c64609873f642
-size 44152
+oid sha256:7badd69bde0d576bd7a6337b9be2688b296b735cc1392a3214c26aa1e20667a0
+size 42577

--- a/public/egc_mskcc_2020/data_clinical_sample.txt
+++ b/public/egc_mskcc_2020/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dab73b3e5bb76c0019b275087b00643de4f2ddbf37a4c9625d498bb18e73b45c
-size 75906
+oid sha256:99689bcb64236457403a6718eb8a9d5664be6aee0c655824fe0070eed337bdb5
+size 75763

--- a/public/gbc_mskcc_2022/data_clinical_sample.txt
+++ b/public/gbc_mskcc_2022/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa06d862c14814600e2a47866c459c40873d9eb13daa3d0d7499a8add82f755a
-size 99951
+oid sha256:621ad82d50405576a0d0f7d5cc0927e5a3ac011bdc4b106bb58133d38e0fc0ac
+size 99715

--- a/public/lung_msk_mind_2020/data_clinical_sample.txt
+++ b/public/lung_msk_mind_2020/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:488072861dfcfeb49d5f83362ad9bda189880572e6df60a00f3cd1f4a85f4481
-size 109752
+oid sha256:47f78b8bf003ad5f1445a116fc655de7c2b3ddc844c024241ec6997ab60d3b11
+size 82707

--- a/public/rectal_msk_2022/data_clinical_sample.txt
+++ b/public/rectal_msk_2022/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b39f1cc7c96a4d530dfd7ba848386bf88cbf6a740a981aef0c3af401aa8970c9
-size 168722
+oid sha256:af4cbb85790b3d86d760fcf0782bedda37d45b981dfbee087afe5a692a8d287b
+size 179372


### PR DESCRIPTION
Update: The germline variants were removed and hence the scores are recalculated.
bowel_colitis_msk_2022
egc_msk_tp53_ccr_2022
egc_mskcc_2020
gbc_mskcc_2022
lung_msk_mind_2020
rectal_msk_2022