### PR TITLE
Update Resource ID for msk_spectrum_tme_2022

### DIFF
--- a/public/msk_spectrum_tme_2022/data_resource_definition.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ccb7dfd1c3e9710bd5d2692a0ef8200c113941d832e953a9165fa9bce9b75d9
-size 174
+oid sha256:9045e60c1df1ef5f131573915c51743054d84188878d7fc4f51e98e16d321447
+size 148

--- a/public/msk_spectrum_tme_2022/data_resource_patient.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a12f273f698b964880fe8affab59110491665b5e713f7cf22de96fb68630a70b
+oid sha256:8a9139bd16d7d3e81dc772f46ce7644700b9afba560e7300851464b7cce331ef
 size 1296


### PR DESCRIPTION
### Update Resource ID for `msk_spectrum_tme_2022`

This PR is part of our ongoing effort to harmonize imaging resource data across studies. It includes the following updates to standardize resource names:

**brca_aurora_2023**: `Pathology Slide` → `H&E Slide`

**msk_spectrum_tme_2022**: `mpIF` → `MxIF`

**crc_orion_2024**: `Minerva Story` → `MxIF`
