### PR TITLE
Update msk_spectrum_tme_2022 data_resource_sample.txt resource url to the cbioportal-public-imaging.assets

### DIFF
--- a/public/msk_spectrum_tme_2022/data_resource_sample.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc6332512fe594baef7b9e044b2560d929290d1e5ecf22137734899fe874ad21
-size 4357
+oid sha256:b4ad5d6878c09228fac5dd9945ab0b9299386afc719e4904d8c5fdfffd467673
+size 5060


### PR DESCRIPTION
fixes cBioportal/cbioportal#11651

Updates `data_resource_sample.txt` to use the current up to date CloudFront distribution
