### PR TITLE
Spectrum Chromoscope

### DIFF
--- a/public/msk_spectrum_tme_2022/data_resource_definition.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3975c93aa377a71fe4d4abe28c17c9f7442f7751ac5d06c20a25081a5e73ca1
-size 156
+oid sha256:3b7c638fff0dcd43d787db456d9f4a3679b288b03f06b763178bc155809ec124
+size 214

--- a/public/msk_spectrum_tme_2022/data_resource_sample.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4ad5d6878c09228fac5dd9945ab0b9299386afc719e4904d8c5fdfffd467673
-size 5060
+oid sha256:cf5dca38c533194749a228d4ebb872e5623f4480b77b121f795309058b0bc4cf
+size 14800


### PR DESCRIPTION

added data and metadata to add Chromoscope as a resource for the MSK Spectrum study

In data_resource_definition.txt, gave Chromoscope priority of 2 - not sure what this mean