### PR TITLE
TMB addition

### DIFF
--- a/public/hcc_clca_2024/data_clinical_sample.txt
+++ b/public/hcc_clca_2024/data_clinical_sample.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a419fa55a0908a11cc2b34e8be5e487aa6d6edccb7eec403b12cf9a48567ad41
-size 102048
+oid sha256:29543c5eeb6b69754bedc77a7b3fc6e85e9e021c962200e38d91e6bae23e2b61
+size 107460


### PR DESCRIPTION
# What?
Fix #[2242](https://github.com/cBioPortal/datahub/issues/2242)

TMB scores added for hcc_clca_2024
TMB score exist in files for hcc_tcga_gdc- reimporting study 