### PR TITLE
Update formatting in gene panels

### DIFF
--- a/reference_data/gene_panels/data_gene_panel_MDSIWG152.txt
+++ b/reference_data/gene_panels/data_gene_panel_MDSIWG152.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29f6c04192b3d2dac1a915753c7a5c5b5c5258bd47c903bdb2ca5b0647e9d0bb
-size 1107
+oid sha256:ae2243b67e9542f12dde196bee5b661fa40b4ad17ba575e9c0b7f83ae18ec877
+size 1097

--- a/reference_data/gene_panels/data_gene_panel_blca_bcan_hcrn_2022.txt
+++ b/reference_data/gene_panels/data_gene_panel_blca_bcan_hcrn_2022.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3a4d422a03483559f5bfad65dd492495f2d9c6e4b4d701f1df52f8a1241e9a6
-size 4718
+oid sha256:1352fb2dceb1f14ced1e2e8a4d01ffa5f798ce4c7b892faa8cb20d0d55e94ada
+size 3540

--- a/reference_data/gene_panels/data_gene_panel_mbn_mdacc_2013.txt
+++ b/reference_data/gene_panels/data_gene_panel_mbn_mdacc_2013.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:301978a1accd18a916773906a386da60b4a831ada8c60bd3d8ed83c368c5d2aa
-size 2476
+oid sha256:918d2e8108db2c4195f4f7de4c89359c734c7faba7aae58167782b66912d5e69
+size 2428


### PR DESCRIPTION
# What?
- Converted spaces to tabs across files: data_gene_panel_blca_bcan_hcrn_2022.txt, data_gene_panel_mbn_mdacc_2013.txt
- Removed two genes from data_gene_panel_MDSIWG152.txt that do not exist anymore.