### PR TITLE
Fix broken CT scan mapping for TCGA-IB-A6UG

### DIFF
--- a/public/paad_tcga_pan_can_atlas_2018/data_resource_patient.txt
+++ b/public/paad_tcga_pan_can_atlas_2018/data_resource_patient.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b36f87c5a17ae7f51c4760b7d0e8a3f531a3ac2d951cdbb5f83cab2d34bc6c5
-size 22709
+oid sha256:4b7245a0a2d2280f39f7daf9551f2e7ba2425baddfd61c69b7d500c44d1c04b7
+size 22587


### PR DESCRIPTION
Fix #2256 
Removed incorrect CT scan resource mapping for TCGA-IB-A6UG which caused the "modality not supported" error in the OHIF viewer.