### PR TITLE
Override 'fetchexclude' in the workflows

### DIFF
--- a/.github/workflows/zip_all_studies_manual.yml
+++ b/.github/workflows/zip_all_studies_manual.yml
@@ -83,7 +83,7 @@ jobs:
             study=$(basename "$studypath")
             study_dir=$(dirname "$studypath")
             echo "Pulling study: ${studypath}."
-            git lfs pull --include="${studypath}"
+            git -c lfs.fetchexclude="" lfs pull --include="${studypath}"
             echo "Compressing this study: ${studypath}."
             tar -czvf studies_to_upload/${study}.tar.gz -C ${study_dir} ${study}
             echo "Copy file to S3: studies_to_upload/${study}.tar.gz"

--- a/.github/workflows/zip_new_studies.yml
+++ b/.github/workflows/zip_new_studies.yml
@@ -103,7 +103,7 @@ jobs:
           changed_study=$(basename "$study_path")
           study_dir=$(dirname "$study_path")
           echo "Pulling study: ${study_path}."
-          git lfs pull --include="${study_path}"
+          git -c lfs.fetchexclude="" lfs pull --include="${study_path}"
           echo "Compressing this study: ${study_path}."
           tar -czvf studies_to_upload/${changed_study}.tar.gz -C ${study_dir} ${changed_study}
           echo "Copy file to S3: studies_to_upload/${changed_study}.tar.gz"


### PR DESCRIPTION
# What?
`.lfsconfig` has `fetchexclude = *` which blocks LFS downloads. Added `git -c lfs.fetchexclude="" lfs pull` to temporarily ignore this rule and fetch the real files before zipping and uploading to S3.

