### PR TITLE
Fix LFS pointer files being read by validator in CircleCI

### DIFF
--- a/.circleci/validate_changed_studies.sh
+++ b/.circleci/validate_changed_studies.sh
@@ -39,8 +39,8 @@ for file_changing in $files_changing; do
           echo "adding to list..."
           list_of_study_dirs+=("$dir_name")
           echo "downloading files from git lfs..."
-          git -c lfs.fetchexclude="" lfs pull -I "$dir_name/*"
-          git -c lfs.fetchexclude="" lfs pull -I "$dir_name/case_lists/*"
+          GIT_LFS_SKIP_SMUDGE=0 git -c lfs.fetchexclude="" lfs pull -I "$dir_name/*"
+          GIT_LFS_SKIP_SMUDGE=0 git -c lfs.fetchexclude="" lfs pull -I "$dir_name/case_lists/*"
         fi
       fi
     done


### PR DESCRIPTION
# What?
Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- a
- b

# checks
For all pull requests:
- [ ] Passes validation

For a new study (in addition to above):
- [ ] Does study name and study ID follow our convention? e.g. Tumor_Type (Institue, Journal Year); brca_mskcc_2015
- [ ] Is the study meta data complete? e.g. pmid, citation
- [ ] Were all samples profiled with WES/WGS? If not, is gene panel file curated?
- [ ] Are oncotree codes of all samples curated; Cancer Type and Cancer Type Detailed needs to be added in addition to Oncotree Code
- [ ] Clinical sample and patient data with meta files.
- [ ] Mutations data with meta file.
- [ ] Is the study based on hg38? If so, is the reference_genome: hg38 option included in meta study.
- [ ] CNA data with meta files
- [ ] CNA segment data with meta files
- [ ] Expression data including z-scores with meta files
- [ ] Other genomic profiles with meta files
- [ ] Case-lists for all profiles.
- [ ] Perform sanity checks based on the items in the [checklist](https://github.com/cBioPortal/datahub/blob/master/docs/curation-process.md)
- [ ] Manual checking (Niki or JJ): Triage or private Portal link here

