### PR TITLE
update resource tab names - use long format

### DIFF
--- a/public/brca_aurora_2023/data_resource_definition.txt
+++ b/public/brca_aurora_2023/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1db2d87cf9ed1195ecae26d4fa3f68b9b86f52e9d125b842187f2e5827436dd
-size 115
+oid sha256:bdb64a0093ad2224ef6d5bcb58318b4f2038964fca1e6a9c3388ad827da2ad25
+size 129

--- a/public/crc_hta11_htan_2021/data_resource_definition.txt
+++ b/public/crc_hta11_htan_2021/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37d3af5f579f019576e7cc2cf2645b07f3535cae22b31f6750afa9f4dc5d0968
-size 154
+oid sha256:687499ad60a9d8f6eee048766f0637c72ab2905a2f60db30bd13bea3b03e8b7a
+size 203

--- a/public/crc_hta8_htan_2024/data_resource_definition.txt
+++ b/public/crc_hta8_htan_2024/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fef2aef5bdb83947c05232052f3f93402dcef0150fb0195178993490a037e4e
-size 117
+oid sha256:4ee95b4662dab771626f842d1fea66339bded6d1733bef789df5729b0fc91b43
+size 152

--- a/public/crc_orion_2024/data_resource_definition.txt
+++ b/public/crc_orion_2024/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d192ac99f1f0c7591417fa181e1f6f393b7e6cfec10f14cda891ff4a22cb0f14
-size 117
+oid sha256:d97b9542a759381cbebf02b201dee91e64012ec1acaacfdd8586d980674f02cf
+size 152

--- a/public/difg_glass/data_resource_definition.txt
+++ b/public/difg_glass/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd2734b810fde1a6090044c297a6ed94443eef70973856bd669c573e88ea1ae6
-size 113
+oid sha256:a720410da69cc0c0080a023cd4d699763f0bafe9ab52b74be0cc45eec70ae57b
+size 127

--- a/public/msk_spectrum_tme_2022/data_resource_definition.txt
+++ b/public/msk_spectrum_tme_2022/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b7c638fff0dcd43d787db456d9f4a3679b288b03f06b763178bc155809ec124
-size 214
+oid sha256:75668c392d2c1b3704375d8ed0ddeb1b38b6bfa4a82b2e3efdef0eed1005ac87
+size 263

--- a/public/ovary_geomx_gray_foundation_2024/data_resource_definition.txt
+++ b/public/ovary_geomx_gray_foundation_2024/data_resource_definition.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b9792685b4e1c68c924233c84712af4af95f70f50a900daa664e3a3fcd6beef
-size 110
+oid sha256:bf42bb5bfda1d44ea92f0f07c3ff01b5bce0bbf8a1dc061cf51820c3d39b9c5f
+size 150


### PR DESCRIPTION
# What?
Using normalized long names for resource tabs. Updated below studies:

Resource Name | New Normalized Name - long name | Studies updated
-- | -- | --
H&E Slide | Slide Microscopy | brca_aurora_2023, crc_hta11_htan_2021, difg_glass, msk_spectrum_tme_2022
CyCIF | Cyclic Immunofluorescence | ovary_geomx_gray_foundation_2024
MxIF Image | Multiplex Immunofluorescence | crc_hta11_htan_2021, crc_hta8_htan_2024, crc_orion_2024, msk_spectrum_tme_2022




