### PR TITLE
msk_spectrum_tme_2022: CD45 sort-fraction caveat + sort-fraction track

### DIFF
--- a/public/msk_spectrum_tme_2022/meta_absolute_counts.txt
+++ b/public/msk_spectrum_tme_2022/meta_absolute_counts.txt
@@ -4,7 +4,7 @@ generic_assay_type: SINGLE_CELL_ABSOLUTE_CELL_TYPE_COUNTS
 datatype: LIMIT-VALUE
 stable_id: cell_type_absolute_counts
 profile_name: Cell Type Absolute Counts
-profile_description: Cell Type Absolute Counts
+profile_description: Cell Type Absolute Counts. Caveat: Counts are derived from CD45 FACS-sorted scRNA-seq, so each sample's composition reflects its sort gate (some samples are immune-only or non-immune-only) rather than whole-tumor cellularity.
 data_filename: data_absolute_counts.txt
 show_profile_in_analysis_tab: true
 pivot_threshold_value: 0.000001

--- a/public/msk_spectrum_tme_2022/meta_cell_gating.txt
+++ b/public/msk_spectrum_tme_2022/meta_cell_gating.txt
@@ -1,0 +1,10 @@
+cancer_study_identifier: msk_spectrum_tme_2022
+genetic_alteration_type: GENERIC_ASSAY
+generic_assay_type: SINGLE_CELL_GATING
+datatype: CATEGORICAL
+stable_id: cell_gating
+profile_name: scRNA Cell Gating
+profile_description: CD45 flow-sort gate(s) sequenced by scRNA-seq for each sample's tumor site (Vazquez-Garcia et al. 2022, Suppl. Table 2). Indicates which compartment(s) the cell-type fraction tracks represent; samples from a single gate show a one-sided (immune-only or non-immune-only) composition rather than whole-tumor cellularity.
+data_filename: data_cell_gating.txt
+show_profile_in_analysis_tab: true
+generic_entity_meta_properties: NAME,DESCRIPTION,URL

--- a/public/msk_spectrum_tme_2022/meta_relative_fraction.txt
+++ b/public/msk_spectrum_tme_2022/meta_relative_fraction.txt
@@ -4,7 +4,7 @@ generic_assay_type: SINGLE_CELL_RELATIVE_CELL_TYPE_COUNTS
 datatype: LIMIT-VALUE
 stable_id: cell_type_relative_counts
 profile_name: Cell Type Relative Fractions
-profile_description: Cell Type Relative Fractions.
+profile_description: Cell Type Relative Fractions. Caveat: Fractions are derived from CD45 FACS-sorted scRNA-seq, so each sample's composition reflects its sort gate (some samples are immune-only or non-immune-only) rather than whole-tumor cellularity.
 data_filename: data_relative_fraction.txt
 show_profile_in_analysis_tab: true
 pivot_threshold_value: 0.000001


### PR DESCRIPTION
## What

Two related additions for `msk_spectrum_tme_2022`, both about the study's **CD45 FACS-sorted** single-cell data:

1. **Caveat in the cell-type profile descriptions** — the relative + absolute cell-type fraction profiles gain a `Caveat:` note. These fractions come from CD45-sorted scRNA-seq, so a sample's composition reflects its sort gate (some samples are immune-only or non-immune-only) rather than whole-tumor cellularity. The frontend renders `Caveat:` as a ⚠ per-track warning (cBioPortal/cbioportal-frontend#5637).

2. **New `CD45 Sort Fraction` generic-assay track** (`SINGLE_CELL_GATING`, categorical) — records which CD45 fraction(s) were actually sequenced per sample (`CD45-positive (immune)` / `CD45-negative (non-immune)` / `CD45-positive and negative` / `Unknown`), derived from the paper's Supplementary Table 2 (aliquot IDs encode `CD45P`/`CD45N`) and matched to sample barcodes via the MSK-IMPACT + Bulk-WGS crosswalks. Keeps all single-cell data under generic assay, and explains the one-sided compositions the caveat warns about.

## Files

- `meta_relative_fraction.txt`, `meta_absolute_counts.txt` — `Caveat:` appended to `profile_description`
- `meta_cell_gating.txt` — new categorical generic-assay profile (in this PR)
- `data_cell_gating.txt` — the sort-fraction values (**LFS — pending push**)

Companion frontend PR: cBioPortal/cbioportal-frontend#5637

🤖 Generated with [Claude Code](https://claude.com/claude-code)
